### PR TITLE
Feat/invite student

### DIFF
--- a/frontend/src/api/invitations.js
+++ b/frontend/src/api/invitations.js
@@ -1,0 +1,5 @@
+import api from '../plugins/axios'
+
+export function sendInvitation(email, role) {
+  return api.post('/api/invitations', { email, role })
+}

--- a/frontend/src/components/UserInviteForm.vue
+++ b/frontend/src/components/UserInviteForm.vue
@@ -5,8 +5,12 @@
       <v-alert v-if="error" type="error" variant="tonal" class="mb-4" closable @click:close="error = ''">
         {{ error }}
       </v-alert>
-      <v-alert v-if="success" type="success" variant="tonal" class="mb-4" closable @click:close="success = ''">
-        {{ success }}
+
+      <v-alert v-if="inviteLink" type="success" variant="tonal" class="mb-4" closable @click:close="inviteLink = ''">
+        Invitation sent. If the email doesn't arrive, share this link directly:
+        <div class="mt-2">
+          <a :href="inviteLink" target="_blank" class="text-break">{{ inviteLink }}</a>
+        </div>
       </v-alert>
 
       <v-text-field
@@ -33,7 +37,7 @@ const emit = defineEmits(['invited'])
 const email = ref('')
 const loading = ref(false)
 const error = ref('')
-const success = ref('')
+const inviteLink = ref('')
 
 async function handleSubmit() {
   if (!email.value) {
@@ -42,11 +46,12 @@ async function handleSubmit() {
   }
 
   error.value = ''
-  success.value = ''
+  inviteLink.value = ''
   loading.value = true
   try {
-    await sendInvitation(email.value, 'STUDENT')
-    success.value = `Invitation sent to ${email.value}.`
+    const response = await sendInvitation(email.value, 'STUDENT')
+    const token = response.data.data
+    inviteLink.value = `${window.location.origin}/register?token=${token}`
     emit('invited', email.value)
     email.value = ''
   } catch (err) {

--- a/frontend/src/components/UserInviteForm.vue
+++ b/frontend/src/components/UserInviteForm.vue
@@ -1,0 +1,58 @@
+<template>
+  <v-card variant="outlined" rounded="lg">
+    <v-card-title class="pa-4 pb-2">Invite Student</v-card-title>
+    <v-card-text class="pa-4 pt-2">
+      <v-alert v-if="error" type="error" variant="tonal" class="mb-4" closable @click:close="error = ''">
+        {{ error }}
+      </v-alert>
+      <v-alert v-if="success" type="success" variant="tonal" class="mb-4" closable @click:close="success = ''">
+        {{ success }}
+      </v-alert>
+
+      <v-text-field
+        v-model="email"
+        label="Student Email"
+        type="email"
+        variant="outlined"
+        class="mb-4"
+      />
+
+      <v-btn color="primary" :loading="loading" @click="handleSubmit">
+        Send Invitation
+      </v-btn>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { sendInvitation } from '../api/invitations'
+
+const emit = defineEmits(['invited'])
+
+const email = ref('')
+const loading = ref(false)
+const error = ref('')
+const success = ref('')
+
+async function handleSubmit() {
+  if (!email.value) {
+    error.value = 'Email is required.'
+    return
+  }
+
+  error.value = ''
+  success.value = ''
+  loading.value = true
+  try {
+    await sendInvitation(email.value, 'STUDENT')
+    success.value = `Invitation sent to ${email.value}.`
+    emit('invited', email.value)
+    email.value = ''
+  } catch (err) {
+    error.value = err.response?.data?.message ?? 'Failed to send invitation.'
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -20,6 +20,7 @@ import TeamFormView from '../views/admin/TeamFormView.vue'
 import RubricsView from '../views/admin/RubricsView.vue'
 import RubricFormView from '../views/admin/RubricFormView.vue'
 import ActiveWeeksView from '../views/admin/ActiveWeeksView.vue'
+import InviteStudentView from '../views/admin/InviteStudentView.vue'
 
 const PlaceholderView = {
   template: `
@@ -72,7 +73,7 @@ const routes = [
       { path: 'rubrics', component: RubricsView },
       { path: 'rubrics/new', component: RubricFormView },
 
-      { path: 'students', component: PlaceholderView },
+      { path: 'students', component: InviteStudentView },
       { path: 'reports', component: PlaceholderView }
     ]
   }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -21,6 +21,7 @@ import RubricsView from '../views/admin/RubricsView.vue'
 import RubricFormView from '../views/admin/RubricFormView.vue'
 import ActiveWeeksView from '../views/admin/ActiveWeeksView.vue'
 import InviteStudentView from '../views/admin/InviteStudentView.vue'
+import StudentsView from '../views/admin/StudentsView.vue'
 
 const PlaceholderView = {
   template: `
@@ -73,7 +74,8 @@ const routes = [
       { path: 'rubrics', component: RubricsView },
       { path: 'rubrics/new', component: RubricFormView },
 
-      { path: 'students', component: InviteStudentView },
+      { path: 'students', component: StudentsView },
+      { path: 'students/invite', component: InviteStudentView },
       { path: 'reports', component: PlaceholderView }
     ]
   }

--- a/frontend/src/views/admin/InviteStudentView.vue
+++ b/frontend/src/views/admin/InviteStudentView.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <div class="mb-6">
+      <div class="text-h3 font-weight-bold">Invite Students</div>
+      <div class="text-h6 text-medium-emphasis">Send an email invitation to a new student.</div>
+    </div>
+
+    <UserInviteForm style="max-width: 600px" />
+  </div>
+</template>
+
+<script setup>
+import UserInviteForm from '../../components/UserInviteForm.vue'
+</script>

--- a/frontend/src/views/admin/StudentsView.vue
+++ b/frontend/src/views/admin/StudentsView.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <div class="d-flex justify-space-between align-center mb-6">
+      <div>
+        <div class="text-h3 font-weight-bold">Students</div>
+        <div class="text-h6 text-medium-emphasis">Search and manage students.</div>
+      </div>
+
+      <v-btn color="primary" to="/students/invite" prepend-icon="mdi-email-plus">
+        Invite Student
+      </v-btn>
+    </div>
+
+    <v-card rounded="xl" elevation="1" class="pa-6">
+      <p class="text-medium-emphasis">Student search coming soon.</p>
+    </v-card>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- Added `frontend/src/api/invitations.js` to call the existing `POST /api/invitations` endpoint
- Implemented `UserInviteForm` component with email input, loading/error states, and a registration link displayed after success in case the email fails to deliver
- Added `InviteStudentView` at `/students/invite` wrapping the invite form
- Added `StudentsView` at `/students` as a placeholder for the student search use case, with an "Invite Student" button linking to `/students/invite`

## Test plan
- [x] Log in as admin and navigate to `/students`
- [x] Click "Invite Student" — should route to `/students/invite`
- [x] Submit with an empty email — should show validation error
- [x] Submit a duplicate email — should show error from API
- [x] Submit a valid email — should show success alert with a `/register?token=...` link
- [x] Confirm the registration link resolves to the register page with the token pre-loaded