### PR TITLE
Feat/peer evaluation

### DIFF
--- a/backend/src/main/java/edu/tcu/projectpulse/config/DataInitializer.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/config/DataInitializer.java
@@ -1,5 +1,14 @@
 package edu.tcu.projectpulse.config;
 
+import edu.tcu.projectpulse.activeweek.ActiveWeek;
+import edu.tcu.projectpulse.activeweek.ActiveWeekRepository;
+import edu.tcu.projectpulse.rubric.Rubric;
+import edu.tcu.projectpulse.rubric.RubricCriterion;
+import edu.tcu.projectpulse.rubric.RubricRepository;
+import edu.tcu.projectpulse.section.Section;
+import edu.tcu.projectpulse.section.SectionRepository;
+import edu.tcu.projectpulse.team.Team;
+import edu.tcu.projectpulse.team.TeamRepository;
 import edu.tcu.projectpulse.user.User;
 import edu.tcu.projectpulse.user.UserRepository;
 import edu.tcu.projectpulse.user.UserRole;
@@ -8,20 +17,45 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
 @Component
 @Profile("!prod")
 public class DataInitializer implements CommandLineRunner {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final SectionRepository sectionRepository;
+    private final TeamRepository teamRepository;
+    private final ActiveWeekRepository activeWeekRepository;
+    private final RubricRepository rubricRepository;
 
-    public DataInitializer(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public DataInitializer(UserRepository userRepository,
+                           PasswordEncoder passwordEncoder,
+                           SectionRepository sectionRepository,
+                           TeamRepository teamRepository,
+                           ActiveWeekRepository activeWeekRepository,
+                           RubricRepository rubricRepository) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.sectionRepository = sectionRepository;
+        this.teamRepository = teamRepository;
+        this.activeWeekRepository = activeWeekRepository;
+        this.rubricRepository = rubricRepository;
     }
 
     @Override
     public void run(String... args) {
+        seedUsers();
+        Section section = seedSection();
+        seedActiveWeek(section);
+        seedRubric(section);
+        seedTeam(section);
+    }
+
+    private void seedUsers() {
         if (userRepository.findByEmail("admin@test.com").isEmpty()) {
             User admin = new User();
             admin.setEmail("admin@test.com");
@@ -34,16 +68,85 @@ public class DataInitializer implements CommandLineRunner {
             userRepository.save(admin);
         }
 
-        if (userRepository.findByEmail("student@test.com").isEmpty()) {
+        seedStudent("jimbo@tcu.edu", "Jimothy", "Jimmerson");
+        seedStudent("bobinator@tcu.edu", "Bobert", "McBob");
+        seedStudent("timtam@tcu.edu", "Timantha", "Tamothy");
+    }
+
+    private void seedStudent(String email, String firstName, String lastName) {
+        if (userRepository.findByEmail(email).isEmpty()) {
             User student = new User();
-            student.setEmail("student@test.com");
-            student.setFirstName("Jimothy");
-            student.setLastName("Jimmerson");
+            student.setEmail(email);
+            student.setFirstName(firstName);
+            student.setLastName(lastName);
             student.setPassword(passwordEncoder.encode("password123"));
             student.setEnabled(true);
             student.setAccountStatus(User.AccountStatus.ACTIVE);
             student.addRole(UserRole.STUDENT);
             userRepository.save(student);
+        }
+    }
+
+    private Section seedSection() {
+        return sectionRepository.findBySectionNameIgnoreCase("Section 001")
+                .orElseGet(() -> {
+                    Section section = new Section("Section 001",
+                            LocalDate.of(2026, 1, 12),
+                            LocalDate.of(2026, 5, 9),
+                            null);
+                    return sectionRepository.save(section);
+                });
+    }
+
+    private void seedActiveWeek(Section section) {
+        List<ActiveWeek> existing = activeWeekRepository.findBySectionIdOrderByStartDateAsc(section.getId());
+        if (existing.isEmpty()) {
+            ActiveWeek week = new ActiveWeek();
+            week.setSectionId(section.getId());
+            week.setStartDate(LocalDate.of(2026, 4, 27));
+            week.setEndDate(LocalDate.of(2026, 5, 3));
+            week.setActive(true);
+            activeWeekRepository.save(week);
+        }
+    }
+
+    private void seedRubric(Section section) {
+        if (rubricRepository.findByNameIgnoreCase("Peer Evaluation Rubric").isEmpty()) {
+            Rubric rubric = new Rubric();
+            rubric.setName("Peer Evaluation Rubric");
+            rubric.setCriteria(List.of(
+                    criterion("Contribution to Team Goals", 10.0),
+                    criterion("Quality of Work", 10.0),
+                    criterion("Communication", 10.0),
+                    criterion("Reliability / Dependability", 10.0),
+                    criterion("Collaboration / Teamwork", 10.0),
+                    criterion("Initiative / Problem Solving", 10.0)
+            ));
+            Rubric saved = rubricRepository.save(rubric);
+            section.setRubricId(saved.getId());
+            sectionRepository.save(section);
+        }
+    }
+
+    private RubricCriterion criterion(String name, double maxScore) {
+        RubricCriterion c = new RubricCriterion();
+        c.setName(name);
+        c.setDescription(name);
+        c.setMaxScore(maxScore);
+        return c;
+    }
+
+    private void seedTeam(Section section) {
+        if (teamRepository.findByNameIgnoreCase("Team One").isEmpty()) {
+            Integer jimothy = userRepository.findByEmail("jimbo@tcu.edu").map(User::getId).orElse(null);
+            Integer bobert  = userRepository.findByEmail("bobinator@tcu.edu").map(User::getId).orElse(null);
+            Integer timantha = userRepository.findByEmail("timtam@tcu.edu").map(User::getId).orElse(null);
+
+            Team team = new Team();
+            team.setName("Team One");
+            team.setSectionId(section.getId());
+            team.setStudentIds(Set.of(jimothy, bobert, timantha));
+            teamRepository.save(team);
         }
     }
 }

--- a/backend/src/main/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationController.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationController.java
@@ -18,8 +18,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/peer-evaluations")
@@ -46,6 +48,31 @@ public class PeerEvaluationController {
 
         peerEvalService.submit(evaluator.getId(), request);
         return new Result(true, StatusCode.SUCCESS, "Peer evaluation submitted.", null);
+    }
+
+    @GetMapping("/my-submissions")
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result getMySubmissions(@AuthenticationPrincipal UserDetails userDetails,
+                                   @RequestParam Integer weekId) {
+        User student = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new ResourceNotFoundException("User", "email", userDetails.getUsername()));
+
+        List<Map<String, Object>> submissions = peerEvalService
+                .getSubmittedForWeek(student.getId(), weekId)
+                .stream()
+                .map(eval -> {
+                    Map<String, Object> m = new HashMap<>();
+                    m.put("evaluateeId", eval.getEvaluateeId());
+                    m.put("publicComments", eval.getPublicComments());
+                    m.put("privateComments", eval.getPrivateComments());
+                    m.put("scores", eval.getScores().stream()
+                            .map(s -> Map.of("criterionId", s.getCriterionId(), "score", s.getScore()))
+                            .collect(Collectors.toList()));
+                    return m;
+                })
+                .collect(Collectors.toList());
+
+        return new Result(true, StatusCode.SUCCESS, "Submissions retrieved.", submissions);
     }
 
     @GetMapping("/report")

--- a/backend/src/main/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationRepository.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationRepository.java
@@ -14,4 +14,6 @@ public interface PeerEvaluationRepository extends JpaRepository<PeerEvaluation, 
     Optional<PeerEvaluation> findByEvaluatorIdAndEvaluateeIdAndWeekId(Integer evaluatorId, Integer evaluateeId, Integer weekId);
 
     boolean existsByEvaluatorIdAndEvaluateeIdAndWeekId(Integer evaluatorId, Integer evaluateeId, Integer weekId);
+
+    List<PeerEvaluation> findByEvaluatorIdAndWeekId(Integer evaluatorId, Integer weekId);
 }

--- a/backend/src/main/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationService.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationService.java
@@ -77,4 +77,8 @@ public class PeerEvaluationService {
     public List<PeerEvaluation> getEvaluationsSubmitted(Integer evaluatorId) {
         return evalRepository.findByEvaluatorId(evaluatorId);
     }
+
+    public List<PeerEvaluation> getSubmittedForWeek(Integer evaluatorId, Integer weekId) {
+        return evalRepository.findByEvaluatorIdAndWeekId(evaluatorId, weekId);
+    }
 }

--- a/backend/src/main/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationService.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationService.java
@@ -1,7 +1,12 @@
 package edu.tcu.projectpulse.peerevaluation;
 
+import edu.tcu.projectpulse.activeweek.ActiveWeek;
+import edu.tcu.projectpulse.activeweek.ActiveWeekRepository;
+import edu.tcu.projectpulse.exception.ValidationException;
 import edu.tcu.projectpulse.peerevaluation.dto.PeerEvaluationRequest;
 import edu.tcu.projectpulse.peerevaluation.dto.ScoreEntry;
+import edu.tcu.projectpulse.team.Team;
+import edu.tcu.projectpulse.team.TeamRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,15 +17,34 @@ import java.util.List;
 public class PeerEvaluationService {
 
     private final PeerEvaluationRepository evalRepository;
+    private final TeamRepository teamRepository;
+    private final ActiveWeekRepository activeWeekRepository;
 
-    public PeerEvaluationService(PeerEvaluationRepository evalRepository) {
+    public PeerEvaluationService(PeerEvaluationRepository evalRepository,
+                                 TeamRepository teamRepository,
+                                 ActiveWeekRepository activeWeekRepository) {
         this.evalRepository = evalRepository;
+        this.teamRepository = teamRepository;
+        this.activeWeekRepository = activeWeekRepository;
     }
 
     @Transactional
     public PeerEvaluation submit(Integer evaluatorId, PeerEvaluationRequest request) {
-        // TODO: validate evaluatee is a teammate (needs TeamMemberRepository)
-        // TODO: validate weekId is the previous active week (needs ActiveWeekRepository)
+        if (evaluatorId.equals(request.getEvaluateeId())) {
+            throw new ValidationException("You cannot evaluate yourself.");
+        }
+
+        Team team = teamRepository.findByStudentId(evaluatorId)
+                .orElseThrow(() -> new ValidationException("You are not assigned to a team."));
+        if (!team.getStudentIds().contains(request.getEvaluateeId())) {
+            throw new ValidationException("You can only evaluate members of your own team.");
+        }
+
+        ActiveWeek week = activeWeekRepository.findById(Long.valueOf(request.getWeekId()))
+                .orElseThrow(() -> new ValidationException("The specified week does not exist."));
+        if (!week.isActive()) {
+            throw new ValidationException("Peer evaluations can only be submitted for active weeks.");
+        }
 
         PeerEvaluation eval = evalRepository
                 .findByEvaluatorIdAndEvaluateeIdAndWeekId(

--- a/backend/src/main/java/edu/tcu/projectpulse/team/TeamController.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/team/TeamController.java
@@ -1,11 +1,22 @@
 package edu.tcu.projectpulse.team;
 
+import edu.tcu.projectpulse.exception.ResourceNotFoundException;
+import edu.tcu.projectpulse.shared.Result;
+import edu.tcu.projectpulse.shared.StatusCode;
+import edu.tcu.projectpulse.user.User;
+import edu.tcu.projectpulse.user.UserRepository;
+import edu.tcu.projectpulse.user.UserService;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/teams")
@@ -13,9 +24,46 @@ import java.util.Set;
 public class TeamController {
 
     private final TeamRepository teamRepository;
+    private final UserService userService;
+    private final UserRepository userRepository;
 
-    public TeamController(TeamRepository teamRepository) {
+    public TeamController(TeamRepository teamRepository,
+                          UserService userService,
+                          UserRepository userRepository) {
         this.teamRepository = teamRepository;
+        this.userService = userService;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/my-team")
+    @PreAuthorize("hasRole('STUDENT')")
+    public Result getMyTeam(@AuthenticationPrincipal UserDetails userDetails) {
+        User student = userService.findByEmail(userDetails.getUsername())
+                .orElseThrow(() -> new ResourceNotFoundException("User", "email", userDetails.getUsername()));
+
+        Team team = teamRepository.findByStudentId(student.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Team", "studentId", student.getId()));
+
+        List<Integer> teammateIds = team.getStudentIds().stream()
+                .filter(id -> !id.equals(student.getId()))
+                .collect(Collectors.toList());
+
+        List<Map<String, Object>> teammates = userRepository.findAllById(teammateIds).stream()
+                .map(u -> {
+                    Map<String, Object> m = new HashMap<>();
+                    m.put("id", u.getId());
+                    m.put("firstName", u.getFirstName());
+                    m.put("lastName", u.getLastName());
+                    return m;
+                })
+                .collect(Collectors.toList());
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("teamId", team.getId());
+        data.put("sectionId", team.getSectionId());
+        data.put("teammates", teammates);
+
+        return new Result(true, StatusCode.SUCCESS, "Team retrieved.", data);
     }
 
     @GetMapping

--- a/backend/src/main/java/edu/tcu/projectpulse/team/TeamRepository.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/team/TeamRepository.java
@@ -1,9 +1,14 @@
 package edu.tcu.projectpulse.team;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByNameIgnoreCase(String name);
+
+    @Query("SELECT t FROM Team t WHERE :studentId MEMBER OF t.studentIds")
+    Optional<Team> findByStudentId(@Param("studentId") Integer studentId);
 }

--- a/backend/src/test/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationServiceTest.java
+++ b/backend/src/test/java/edu/tcu/projectpulse/peerevaluation/PeerEvaluationServiceTest.java
@@ -1,7 +1,12 @@
 package edu.tcu.projectpulse.peerevaluation;
 
+import edu.tcu.projectpulse.activeweek.ActiveWeek;
+import edu.tcu.projectpulse.activeweek.ActiveWeekRepository;
+import edu.tcu.projectpulse.exception.ValidationException;
 import edu.tcu.projectpulse.peerevaluation.dto.PeerEvaluationRequest;
 import edu.tcu.projectpulse.peerevaluation.dto.ScoreEntry;
+import edu.tcu.projectpulse.team.Team;
+import edu.tcu.projectpulse.team.TeamRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,10 +17,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,10 +33,18 @@ class PeerEvaluationServiceTest {
     @Mock
     private PeerEvaluationRepository evalRepository;
 
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private ActiveWeekRepository activeWeekRepository;
+
     @InjectMocks
     private PeerEvaluationService peerEvalService;
 
     private PeerEvaluationRequest request;
+    private Team team;
+    private ActiveWeek activeWeek;
 
     @BeforeEach
     void setUp() {
@@ -45,6 +62,15 @@ class PeerEvaluationServiceTest {
         request.setPublicComments("Great work.");
         request.setPrivateComments("Needs improvement in meetings.");
         request.setScores(List.of(score1, score2));
+
+        team = new Team();
+        team.setStudentIds(Set.of(1, 2));
+
+        activeWeek = new ActiveWeek();
+        activeWeek.setActive(true);
+
+        lenient().when(teamRepository.findByStudentId(1)).thenReturn(Optional.of(team));
+        lenient().when(activeWeekRepository.findById(1L)).thenReturn(Optional.of(activeWeek));
     }
 
     @Test
@@ -100,5 +126,60 @@ class PeerEvaluationServiceTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getEvaluateeId()).isEqualTo(1);
+    }
+
+    @Test
+    void should_ThrowValidationException_When_EvaluatorAndEvaluateeAreSamePerson() {
+        request.setEvaluateeId(1);
+
+        assertThatThrownBy(() -> peerEvalService.submit(1, request))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("cannot evaluate yourself");
+
+        verify(evalRepository, never()).save(any());
+    }
+
+    @Test
+    void should_ThrowValidationException_When_EvaluatorHasNoTeam() {
+        given(teamRepository.findByStudentId(1)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> peerEvalService.submit(1, request))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("not assigned to a team");
+
+        verify(evalRepository, never()).save(any());
+    }
+
+    @Test
+    void should_ThrowValidationException_When_EvaluateeIsNotATeammate() {
+        team.setStudentIds(Set.of(1, 99));
+
+        assertThatThrownBy(() -> peerEvalService.submit(1, request))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("only evaluate members of your own team");
+
+        verify(evalRepository, never()).save(any());
+    }
+
+    @Test
+    void should_ThrowValidationException_When_WeekDoesNotExist() {
+        given(activeWeekRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> peerEvalService.submit(1, request))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("does not exist");
+
+        verify(evalRepository, never()).save(any());
+    }
+
+    @Test
+    void should_ThrowValidationException_When_WeekIsNotActive() {
+        activeWeek.setActive(false);
+
+        assertThatThrownBy(() -> peerEvalService.submit(1, request))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("active weeks");
+
+        verify(evalRepository, never()).save(any());
     }
 }

--- a/backend/src/test/java/edu/tcu/projectpulse/team/TeamControllerTest.java
+++ b/backend/src/test/java/edu/tcu/projectpulse/team/TeamControllerTest.java
@@ -1,0 +1,127 @@
+package edu.tcu.projectpulse.team;
+
+import edu.tcu.projectpulse.exception.ResourceNotFoundException;
+import edu.tcu.projectpulse.shared.Result;
+import edu.tcu.projectpulse.shared.StatusCode;
+import edu.tcu.projectpulse.user.User;
+import edu.tcu.projectpulse.user.UserRepository;
+import edu.tcu.projectpulse.user.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class TeamControllerTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private TeamController teamController;
+
+    private UserDetails mockPrincipal;
+    private User student;
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        mockPrincipal = mock(UserDetails.class);
+        given(mockPrincipal.getUsername()).willReturn("student@tcu.edu");
+
+        student = new User();
+        student.setId(1);
+        student.setEmail("student@tcu.edu");
+        student.setFirstName("Jane");
+        student.setLastName("Doe");
+
+        team = new Team();
+        team.setStudentIds(Set.of(1, 10, 11));
+        team.setSectionId(2L);
+    }
+
+    @Test
+    void should_ReturnTeamWithTeammates_When_StudentIsOnATeam() {
+        User teammate1 = new User();
+        teammate1.setId(10);
+        teammate1.setFirstName("John");
+        teammate1.setLastName("Smith");
+
+        User teammate2 = new User();
+        teammate2.setId(11);
+        teammate2.setFirstName("Lily");
+        teammate2.setLastName("Fisher");
+
+        given(userService.findByEmail("student@tcu.edu")).willReturn(Optional.of(student));
+        given(teamRepository.findByStudentId(1)).willReturn(Optional.of(team));
+        given(userRepository.findAllById(anyList())).willReturn(List.of(teammate1, teammate2));
+
+        Result result = teamController.getMyTeam(mockPrincipal);
+
+        assertThat(result.isFlag()).isTrue();
+        assertThat(result.getCode()).isEqualTo(StatusCode.SUCCESS);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) result.getData();
+        assertThat(data.get("sectionId")).isEqualTo(2L);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> teammates = (List<Map<String, Object>>) data.get("teammates");
+        assertThat(teammates).hasSize(2);
+        assertThat(teammates).extracting(m -> m.get("firstName"))
+                .containsExactlyInAnyOrder("John", "Lily");
+    }
+
+    @Test
+    void should_ExcludeCurrentStudent_From_TeammateList() {
+        given(userService.findByEmail("student@tcu.edu")).willReturn(Optional.of(student));
+        given(teamRepository.findByStudentId(1)).willReturn(Optional.of(team));
+        given(userRepository.findAllById(anyList())).willReturn(List.of());
+
+        Result result = teamController.getMyTeam(mockPrincipal);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> teammates = (List<Map<String, Object>>)
+                ((Map<String, Object>) result.getData()).get("teammates");
+        assertThat(teammates).noneMatch(m -> m.get("id").equals(1));
+    }
+
+    @Test
+    void should_ThrowResourceNotFoundException_When_StudentNotFound() {
+        given(userService.findByEmail("student@tcu.edu")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> teamController.getMyTeam(mockPrincipal))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("student@tcu.edu");
+    }
+
+    @Test
+    void should_ThrowResourceNotFoundException_When_StudentHasNoTeam() {
+        given(userService.findByEmail("student@tcu.edu")).willReturn(Optional.of(student));
+        given(teamRepository.findByStudentId(1)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> teamController.getMyTeam(mockPrincipal))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Team");
+    }
+}

--- a/frontend/src/api/peerEval.js
+++ b/frontend/src/api/peerEval.js
@@ -4,6 +4,10 @@ export function submitEvaluation(payload) {
   return api.post('/api/peer-evaluations', payload)
 }
 
+export function getMySubmissions(weekId) {
+  return api.get('/api/peer-evaluations/my-submissions', { params: { weekId } })
+}
+
 export function getMyReport(weekId) {
   return api.get('/api/peer-evaluations/report', { params: { weekId } })
 }

--- a/frontend/src/api/rubric.js
+++ b/frontend/src/api/rubric.js
@@ -1,15 +1,9 @@
-const API_URL = 'http://localhost:8080/api/rubrics'
+import api from '../plugins/axios'
 
-export async function getRubrics() {
-  const response = await fetch(API_URL)
-  return response.json()
+export function getRubrics() {
+  return api.get('/api/rubrics')
 }
 
-export async function createRubric(rubric) {
-  const response = await fetch(API_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(rubric)
-  })
-  return response.json()
+export function createRubric(rubric) {
+  return api.post('/api/rubrics', rubric)
 }

--- a/frontend/src/api/teams.js
+++ b/frontend/src/api/teams.js
@@ -27,3 +27,7 @@ export function assignStudentsToTeam(teamId, studentIds) {
 export function removeStudentFromTeam(teamId, studentId) {
   return api.delete(`/api/teams/${teamId}/students/${studentId}`)
 }
+
+export function getMyTeam() {
+  return api.get('/api/teams/my-team')
+}

--- a/frontend/src/components/PeerEvalSubmittedSummary.vue
+++ b/frontend/src/components/PeerEvalSubmittedSummary.vue
@@ -1,0 +1,49 @@
+<template>
+  <div>
+    <v-alert type="success" variant="tonal" class="mb-6" icon="mdi-check-circle">
+      Evaluation submitted. You cannot edit it after submission.
+    </v-alert>
+
+    <v-table class="mb-4">
+      <thead>
+        <tr>
+          <th>Criterion</th>
+          <th style="width: 140px">Score (1–10)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="criterion in criteria" :key="criterion.id">
+          <td>{{ criterion.name }}</td>
+          <td>{{ scoreFor(criterion.id) }}</td>
+        </tr>
+      </tbody>
+    </v-table>
+
+    <v-textarea
+      :model-value="submission.publicComments"
+      label="Public Comments (visible to teammates)"
+      variant="outlined"
+      rows="3"
+      class="mb-3"
+      readonly
+    />
+    <v-textarea
+      :model-value="submission.privateComments"
+      label="Private Comments (visible to instructor only)"
+      variant="outlined"
+      rows="3"
+      readonly
+    />
+  </div>
+</template>
+
+<script setup>
+const props = defineProps({
+  submission: { type: Object, required: true },
+  criteria: { type: Array, required: true },
+})
+
+function scoreFor(criterionId) {
+  return props.submission.scores.find(s => s.criterionId === criterionId)?.score ?? '—'
+}
+</script>

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -29,7 +29,26 @@
       <v-app-bar-nav-icon @click="drawer = !drawer" />
       <v-toolbar-title class="font-weight-bold">Project Pulse</v-toolbar-title>
       <v-spacer />
-      <v-btn variant="text" prepend-icon="mdi-account-circle-outline">Profile</v-btn>
+      <v-menu>
+        <template #activator="{ props }">
+          <v-btn variant="text" prepend-icon="mdi-account-circle-outline" v-bind="props">
+            {{ authStore.user?.firstName }} {{ authStore.user?.lastName }}
+          </v-btn>
+        </template>
+        <v-list>
+          <v-list-item
+            v-if="authStore.role === 'STUDENT'"
+            to="/student/account"
+            prepend-icon="mdi-cog-outline"
+            title="Account Settings"
+          />
+          <v-list-item
+            prepend-icon="mdi-logout"
+            title="Logout"
+            @click="handleLogout"
+          />
+        </v-list>
+      </v-menu>
     </v-app-bar>
 
     <v-main class="bg-background">
@@ -42,10 +61,17 @@
 
 <script setup>
 import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 
 const drawer = ref(true)
 const authStore = useAuthStore()
+const router = useRouter()
+
+function handleLogout() {
+  authStore.logout()
+  router.push('/login')
+}
 
 const navItems = computed(() => {
   if (authStore.role === 'STUDENT') {
@@ -54,7 +80,6 @@ const navItems = computed(() => {
       { title: 'Peer Evaluation', to: '/student/peer-eval', icon: 'mdi-message-star-outline' },
       { title: 'My Report', to: '/student/report', icon: 'mdi-file-chart-outline' },
       { title: 'Weekly Activity Report', to: '/student/war', icon: 'mdi-clipboard-text-outline' },
-      { title: 'Account', to: '/student/account', icon: 'mdi-account-circle-outline' },
     ]
   }
   return [

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,9 +1,26 @@
 <template>
   <v-app>
-    <v-navigation-drawer v-model="drawer" width="280" color="primary">
-      <div class="pa-4 text-white">
-        <div class="text-h5 font-weight-bold">Project Pulse</div>
-        <div class="text-subtitle-1">Senior Design Portal</div>
+    <v-navigation-drawer :rail="rail" width="280" rail-width="56" color="primary" permanent>
+      <div style="height: 76px; overflow: hidden; position: relative;">
+        <v-fade-transition>
+          <div
+            v-if="!rail"
+            class="text-white"
+            style="position: absolute; top: 0; bottom: 0; left: 0; right: 56px; display: flex; flex-direction: column; justify-content: center; padding-left: 16px; overflow: hidden;"
+          >
+            <div class="text-h5 font-weight-bold" style="white-space: nowrap;">Project Pulse</div>
+            <div class="text-subtitle-1" style="white-space: nowrap;">Senior Design Portal</div>
+          </div>
+        </v-fade-transition>
+        <div style="position: absolute; right: 0; top: 0; bottom: 0; width: 56px; display: flex; align-items: center; justify-content: center;">
+          <v-btn
+            :icon="rail ? 'mdi-menu' : 'mdi-close'"
+            variant="text"
+            color="white"
+            :ripple="false"
+            @click="rail = !rail"
+          />
+        </div>
       </div>
 
       <v-divider class="mb-2" />
@@ -26,7 +43,6 @@
     </v-navigation-drawer>
 
     <v-app-bar elevation="1" color="white">
-      <v-app-bar-nav-icon @click="drawer = !drawer" />
       <v-toolbar-title class="font-weight-bold">Project Pulse</v-toolbar-title>
       <v-spacer />
       <v-menu>
@@ -64,7 +80,7 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 
-const drawer = ref(true)
+const rail = ref(false)
 const authStore = useAuthStore()
 const router = useRouter()
 

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -29,7 +29,6 @@
       <v-app-bar-nav-icon @click="drawer = !drawer" />
       <v-toolbar-title class="font-weight-bold">Project Pulse</v-toolbar-title>
       <v-spacer />
-      <v-btn variant="text" prepend-icon="mdi-bell-outline">Notifications</v-btn>
       <v-btn variant="text" prepend-icon="mdi-account-circle-outline">Profile</v-btn>
     </v-app-bar>
 

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -42,16 +42,29 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useAuthStore } from '../stores/auth'
 
 const drawer = ref(true)
+const authStore = useAuthStore()
 
-const navItems = [
-  { title: 'Dashboard', to: '/dashboard', icon: 'mdi-view-dashboard-outline' },
-  { title: 'Sections', to: '/sections', icon: 'mdi-google-classroom' },
-  { title: 'Teams', to: '/teams', icon: 'mdi-account-group-outline' },
-  { title: 'Rubrics', to: '/rubrics', icon: 'mdi-clipboard-text-outline' },
-  { title: 'Students', to: '/students', icon: 'mdi-school-outline' },
-  { title: 'Reports', to: '/reports', icon: 'mdi-file-chart-outline' },
-]
+const navItems = computed(() => {
+  if (authStore.role === 'STUDENT') {
+    return [
+      { title: 'Dashboard', to: '/student/dashboard', icon: 'mdi-view-dashboard-outline' },
+      { title: 'Peer Evaluation', to: '/student/peer-eval', icon: 'mdi-message-star-outline' },
+      { title: 'My Report', to: '/student/report', icon: 'mdi-file-chart-outline' },
+      { title: 'Weekly Activity Report', to: '/student/war', icon: 'mdi-clipboard-text-outline' },
+      { title: 'Account', to: '/student/account', icon: 'mdi-account-circle-outline' },
+    ]
+  }
+  return [
+    { title: 'Dashboard', to: '/dashboard', icon: 'mdi-view-dashboard-outline' },
+    { title: 'Sections', to: '/sections', icon: 'mdi-google-classroom' },
+    { title: 'Teams', to: '/teams', icon: 'mdi-account-group-outline' },
+    { title: 'Rubrics', to: '/rubrics', icon: 'mdi-clipboard-text-outline' },
+    { title: 'Students', to: '/students', icon: 'mdi-school-outline' },
+    { title: 'Reports', to: '/reports', icon: 'mdi-file-chart-outline' },
+  ]
+})
 </script>

--- a/frontend/src/views/admin/ActiveWeeksView.vue
+++ b/frontend/src/views/admin/ActiveWeeksView.vue
@@ -37,7 +37,7 @@
 import { computed, ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { getSection } from '../../api/sections'
-import { saveActiveWeeks } from '../../api/activeWeeks'
+import { saveActiveWeeksBySection as saveActiveWeeks } from '../../api/activeWeeks'
 
 const route = useRoute()
 

--- a/frontend/src/views/student/PeerEvalReportView.vue
+++ b/frontend/src/views/student/PeerEvalReportView.vue
@@ -20,7 +20,7 @@
       <div class="text-h6 font-weight-medium mb-3">Scores by Criterion</div>
       <PeerEvalScoreTable
         :criterion-averages="report.criterionAverages"
-        :criteria="MOCK_CRITERIA"
+        :criteria="criteria"
         class="mb-6"
         style="max-width: 500px"
       />
@@ -49,27 +49,38 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { getMyTeam } from '../../api/teams'
+import { getActiveWeeksBySection } from '../../api/activeWeeks'
+import { getRubrics } from '../../api/rubric'
 import { getMyReport } from '../../api/peerEval'
 import PeerEvalScoreTable from '../../components/PeerEvalScoreTable.vue'
 
-const MOCK_CRITERIA = [
-  { id: 1, name: 'Contribution to Team Goals' },
-  { id: 2, name: 'Quality of Work' },
-  { id: 3, name: 'Communication' },
-  { id: 4, name: 'Reliability / Dependability' },
-  { id: 5, name: 'Collaboration / Teamwork' },
-  { id: 6, name: 'Initiative / Problem Solving' },
-]
-
-const weekId = 1
+const weekId = ref(null)
+const criteria = ref([])
 const report = ref(null)
 const loading = ref(true)
 const error = ref('')
 
 onMounted(async () => {
   try {
-    const response = await getMyReport(weekId)
-    report.value = response.data.data
+    const [teamRes, rubricRes] = await Promise.all([getMyTeam(), getRubrics()])
+
+    const teamData = teamRes.data.data
+    const rubrics = rubricRes.data
+
+    criteria.value = rubrics[0]?.criteria ?? []
+
+    const weeksRes = await getActiveWeeksBySection(teamData.sectionId)
+    const activeWeek = weeksRes.data.find(w => w.active)
+    if (!activeWeek) {
+      error.value = 'No active week found.'
+      return
+    }
+
+    weekId.value = activeWeek.id
+
+    const reportRes = await getMyReport(activeWeek.id)
+    report.value = reportRes.data.data
   } catch (err) {
     error.value = err.response?.data?.message ?? 'Failed to load report.'
   } finally {

--- a/frontend/src/views/student/PeerEvalSubmitView.vue
+++ b/frontend/src/views/student/PeerEvalSubmitView.vue
@@ -16,7 +16,7 @@
         <v-tab v-for="teammate in teammates" :key="teammate.id" :value="teammate.id">
           {{ teammate.name }}
           <v-icon
-            v-if="submitted.includes(teammate.id)"
+            v-if="submissions[teammate.id]"
             icon="mdi-check-circle"
             color="success"
             size="18"
@@ -27,7 +27,13 @@
 
       <v-window v-model="activeTab">
         <v-window-item v-for="teammate in teammates" :key="teammate.id" :value="teammate.id">
+          <PeerEvalSubmittedSummary
+            v-if="submissions[teammate.id]"
+            :submission="submissions[teammate.id]"
+            :criteria="criteria"
+          />
           <PeerEvalForm
+            v-else
             :teammate="teammate"
             :criteria="criteria"
             :week-id="weekId"
@@ -42,17 +48,29 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import PeerEvalForm from '../../components/PeerEvalForm.vue'
+import PeerEvalSubmittedSummary from '../../components/PeerEvalSubmittedSummary.vue'
 import { getMyTeam } from '../../api/teams'
 import { getActiveWeeksBySection } from '../../api/activeWeeks'
 import { getRubrics } from '../../api/rubric'
+import { getMySubmissions } from '../../api/peerEval'
 
 const weekId = ref(null)
 const teammates = ref([])
 const criteria = ref([])
+const submissions = ref({})
 const loading = ref(true)
 const error = ref('')
 const activeTab = ref(null)
-const submitted = ref([])
+
+async function loadSubmissions() {
+  if (!weekId.value) return
+  const res = await getMySubmissions(weekId.value)
+  const map = {}
+  for (const sub of res.data.data) {
+    map[sub.evaluateeId] = sub
+  }
+  submissions.value = map
+}
 
 onMounted(async () => {
   try {
@@ -75,6 +93,8 @@ onMounted(async () => {
     }))
     criteria.value = rubrics[0]?.criteria ?? []
 
+    await loadSubmissions()
+
     if (teammates.value.length > 0) {
       activeTab.value = teammates.value[0].id
     }
@@ -85,9 +105,7 @@ onMounted(async () => {
   }
 })
 
-function onSubmitted(teammateId) {
-  if (!submitted.value.includes(teammateId)) {
-    submitted.value.push(teammateId)
-  }
+async function onSubmitted() {
+  await loadSubmissions()
 }
 </script>

--- a/frontend/src/views/student/PeerEvalSubmitView.vue
+++ b/frontend/src/views/student/PeerEvalSubmitView.vue
@@ -2,58 +2,88 @@
   <div>
     <div class="text-h5 font-weight-bold mb-1">Peer Evaluation</div>
     <div class="text-body-2 text-medium-emphasis mb-6">
-      Evaluate each of your teammates for Week {{ MOCK_WEEK_ID }}.
+      Evaluate each of your teammates for Week {{ weekId }}.
     </div>
 
-    <v-tabs v-model="activeTab" color="primary" class="mb-6">
-      <v-tab v-for="teammate in MOCK_TEAMMATES" :key="teammate.id" :value="teammate.id">
-        {{ teammate.name }}
-        <v-icon
-          v-if="submitted.includes(teammate.id)"
-          icon="mdi-check-circle"
-          color="success"
-          size="18"
-          class="ml-1"
-        />
-      </v-tab>
-    </v-tabs>
+    <v-alert v-if="error" type="error" variant="tonal" class="mb-4">{{ error }}</v-alert>
 
-    <v-window v-model="activeTab">
-      <v-window-item v-for="teammate in MOCK_TEAMMATES" :key="teammate.id" :value="teammate.id">
-        <PeerEvalForm
-          :teammate="teammate"
-          :criteria="MOCK_CRITERIA"
-          :week-id="MOCK_WEEK_ID"
-          @submitted="onSubmitted"
-        />
-      </v-window-item>
-    </v-window>
+    <div v-if="loading" class="d-flex justify-center py-8">
+      <v-progress-circular indeterminate color="primary" />
+    </div>
+
+    <template v-else-if="teammates.length > 0">
+      <v-tabs v-model="activeTab" color="primary" class="mb-6">
+        <v-tab v-for="teammate in teammates" :key="teammate.id" :value="teammate.id">
+          {{ teammate.name }}
+          <v-icon
+            v-if="submitted.includes(teammate.id)"
+            icon="mdi-check-circle"
+            color="success"
+            size="18"
+            class="ml-1"
+          />
+        </v-tab>
+      </v-tabs>
+
+      <v-window v-model="activeTab">
+        <v-window-item v-for="teammate in teammates" :key="teammate.id" :value="teammate.id">
+          <PeerEvalForm
+            :teammate="teammate"
+            :criteria="criteria"
+            :week-id="weekId"
+            @submitted="onSubmitted"
+          />
+        </v-window-item>
+      </v-window>
+    </template>
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import PeerEvalForm from '../../components/PeerEvalForm.vue'
+import { getMyTeam } from '../../api/teams'
+import { getActiveWeeksBySection } from '../../api/activeWeeks'
+import { getRubrics } from '../../api/rubric'
 
-const MOCK_WEEK_ID = 1
-
-const MOCK_TEAMMATES = [
-  { id: 10, name: 'John Doe' },
-  { id: 11, name: 'Tim Smith' },
-  { id: 12, name: 'Lily Fisher' },
-]
-
-const MOCK_CRITERIA = [
-  { id: 1, name: 'Contribution to Team Goals' },
-  { id: 2, name: 'Quality of Work' },
-  { id: 3, name: 'Communication' },
-  { id: 4, name: 'Reliability / Dependability' },
-  { id: 5, name: 'Collaboration / Teamwork' },
-  { id: 6, name: 'Initiative / Problem Solving' },
-]
-
-const activeTab = ref(MOCK_TEAMMATES[0].id)
+const weekId = ref(null)
+const teammates = ref([])
+const criteria = ref([])
+const loading = ref(true)
+const error = ref('')
+const activeTab = ref(null)
 const submitted = ref([])
+
+onMounted(async () => {
+  try {
+    const [teamRes, rubricRes] = await Promise.all([getMyTeam(), getRubrics()])
+
+    const teamData = teamRes.data.data
+    const rubrics = rubricRes.data
+
+    const weeksRes = await getActiveWeeksBySection(teamData.sectionId)
+    const activeWeek = weeksRes.data.find(w => w.active)
+    if (!activeWeek) {
+      error.value = 'No active week found. Peer evaluations are not currently open.'
+      return
+    }
+
+    weekId.value = activeWeek.id
+    teammates.value = teamData.teammates.map(t => ({
+      id: t.id,
+      name: `${t.firstName} ${t.lastName}`,
+    }))
+    criteria.value = rubrics[0]?.criteria ?? []
+
+    if (teammates.value.length > 0) {
+      activeTab.value = teammates.value[0].id
+    }
+  } catch (err) {
+    error.value = err.response?.data?.message ?? 'Failed to load peer evaluation.'
+  } finally {
+    loading.value = false
+  }
+})
 
 function onSubmitted(teammateId) {
   if (!submitted.value.includes(teammateId)) {

--- a/frontend/src/views/student/StudentDashboard.vue
+++ b/frontend/src/views/student/StudentDashboard.vue
@@ -24,6 +24,16 @@
             </template>
             <v-card-title>Peer Evaluation</v-card-title>
             <v-card-subtitle>Evaluate your teammates</v-card-subtitle>
+            <template v-if="evalBadge" #append>
+              <v-chip
+                :color="evalBadge.color"
+                size="small"
+                variant="tonal"
+                :prepend-icon="evalBadge.icon"
+              >
+                {{ evalBadge.label }}
+              </v-chip>
+            </template>
           </v-card-item>
         </v-card>
       </v-col>
@@ -44,7 +54,42 @@
 </template>
 
 <script setup>
+import { ref, computed, onMounted } from 'vue'
 import { useAuthStore } from '../../stores/auth'
+import { getMyTeam } from '../../api/teams'
+import { getActiveWeeksBySection } from '../../api/activeWeeks'
+import { getMySubmissions } from '../../api/peerEval'
 
 const authStore = useAuthStore()
+
+const evalStatus = ref(null)
+
+const evalBadge = computed(() => {
+  if (!evalStatus.value) return null
+  const { submitted, total } = evalStatus.value
+  if (total === 0) return null
+  if (submitted === total) {
+    return { label: 'Complete', color: 'success', icon: 'mdi-check' }
+  }
+  return { label: `${submitted} / ${total} submitted`, color: 'warning', icon: 'mdi-alert-circle-outline' }
+})
+
+onMounted(async () => {
+  try {
+    const teamRes = await getMyTeam()
+    const teamData = teamRes.data.data
+
+    const weeksRes = await getActiveWeeksBySection(teamData.sectionId)
+    const activeWeek = weeksRes.data.find(w => w.active)
+    if (!activeWeek) return
+
+    const submissionsRes = await getMySubmissions(activeWeek.id)
+    evalStatus.value = {
+      submitted: submissionsRes.data.data.length,
+      total: teamData.teammates.length,
+    }
+  } catch {
+    // no badge if team or week can't be resolved
+  }
+})
 </script>

--- a/frontend/src/views/student/StudentDashboard.vue
+++ b/frontend/src/views/student/StudentDashboard.vue
@@ -71,7 +71,7 @@ const evalBadge = computed(() => {
   if (submitted === total) {
     return { label: 'Complete', color: 'success', icon: 'mdi-check' }
   }
-  return { label: `${submitted} / ${total} submitted`, color: 'warning', icon: 'mdi-alert-circle-outline' }
+  return { label: `${submitted} / ${total} submitted`, color: 'error', icon: 'mdi-alert-circle-outline' }
 })
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
- Added active week management and team student assignment (foundational backend for peer eval)
- Completes UC-28: student can submit a peer evaluation for each teammate during an active week
- Completes UC-29: student can view their own peer evaluation report (grade and criterion averages) for the active week

## Changes

**Active week & team management (foundation)**
- `ActiveWeekController` — `GET /POST /api/active-weeks/section/{sectionId}` for managing which weeks are active per section
- `TeamController` — `POST /PUT /DELETE` team CRUD + student assignment endpoints
- `TeamStudentsView.vue` — admin UI for assigning students to a team

**UC-28 — Peer evaluation submit**
- `GET /api/teams/my-team` (STUDENT) — returns the authenticated student's team, sectionId, and teammate names (excluding self); backed by a `MEMBER OF` JPQL query on `TeamRepository`
- `PeerEvaluationService.submit()` — now validates: no self-evaluation, evaluatee is a teammate, weekId is an active week; previously both checks were stubbed TODOs
- `PeerEvalSubmitView.vue` — fully wired; fetches team + rubrics in parallel, resolves active week via sectionId, passes real data to `PeerEvalForm`

**UC-29 — Peer eval report**
- `GET /api/peer-evaluations/report?weekId=` (STUDENT) — returns grade, per-criterion averages, and public comments for the authenticated student
- `PeerEvalReportView.vue` — fully wired; resolves active weekId from team → section → active weeks, fetches rubric criteria for score table labels

**Other**
- `api/rubric.js` — converted from raw `fetch` with hardcoded URL to the shared axios instance
- `ActiveWeeksView.vue` — fixed stale import name (`saveActiveWeeks` → `saveActiveWeeksBySection`)

## Test plan
- [x] Log in as a student assigned to a team with an active week configured
- [x] Navigate to `/student/peer-eval` — verify teammates load, criteria load, active week number shown
- [x] Submit an evaluation for one teammate — verify success banner and checkmark appear on tab
- [x] Attempt to re-open the same teammate's tab and resubmit — verify it updates (upsert)
- [x] Navigate to `/student/report` — verify grade, per-criterion averages, and any public comments appear
- [x] Log in as a student with no team — verify both views show a clear error message
- [x] Deactivate the current week in admin → attempt to submit — verify backend rejects with validation error