### PR TITLE
Feat/weekly activity report

### DIFF
--- a/backend/src/main/java/edu/tcu/projectpulse/activeweek/ActiveWeekController.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/activeweek/ActiveWeekController.java
@@ -2,7 +2,10 @@ package edu.tcu.projectpulse.activeweek;
 
 import edu.tcu.projectpulse.section.Section;
 import edu.tcu.projectpulse.section.SectionRepository;
+import edu.tcu.projectpulse.shared.Result;
+import edu.tcu.projectpulse.shared.StatusCode;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,11 +21,14 @@ public class ActiveWeekController {
 
     private final ActiveWeekRepository activeWeekRepository;
     private final SectionRepository sectionRepository;
+    private final ActiveWeekService activeWeekService;
 
     public ActiveWeekController(ActiveWeekRepository activeWeekRepository,
-                                SectionRepository sectionRepository) {
+                                SectionRepository sectionRepository,
+                                ActiveWeekService activeWeekService) {
         this.activeWeekRepository = activeWeekRepository;
         this.sectionRepository = sectionRepository;
+        this.activeWeekService = activeWeekService;
     }
 
     @GetMapping("/section/{sectionId}")
@@ -37,6 +43,13 @@ public class ActiveWeekController {
                 .orElseThrow(() -> new IllegalArgumentException("Section not found"));
 
         return generateWeeks(section);
+    }
+
+    @GetMapping("/section/{sectionId}/available")
+    @PreAuthorize("hasAnyRole('STUDENT', 'INSTRUCTOR')")
+    public Result getAvailableWeeksForSection(@PathVariable Long sectionId) {
+        List<ActiveWeek> weeks = activeWeekService.getWeeksForSection(sectionId);
+        return new Result(true, StatusCode.SUCCESS, "Active weeks retrieved.", weeks);
     }
 
     @PostMapping("/section/{sectionId}")

--- a/backend/src/main/java/edu/tcu/projectpulse/activeweek/ActiveWeekRepository.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/activeweek/ActiveWeekRepository.java
@@ -1,9 +1,12 @@
 package edu.tcu.projectpulse.activeweek;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ActiveWeekRepository extends JpaRepository<ActiveWeek, Long> {
     List<ActiveWeek> findBySectionIdOrderByStartDateAsc(Long sectionId);
     void deleteBySectionId(Long sectionId);
+    List<ActiveWeek> findBySectionIdAndActiveTrueAndStartDateLessThanEqualOrderByStartDateDesc(Long sectionId, LocalDate today);
 }

--- a/backend/src/main/java/edu/tcu/projectpulse/activeweek/ActiveWeekService.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/activeweek/ActiveWeekService.java
@@ -1,0 +1,21 @@
+package edu.tcu.projectpulse.activeweek;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class ActiveWeekService {
+
+    private final ActiveWeekRepository activeWeekRepository;
+
+    public ActiveWeekService(ActiveWeekRepository activeWeekRepository) {
+        this.activeWeekRepository = activeWeekRepository;
+    }
+
+    public List<ActiveWeek> getWeeksForSection(Long sectionId) {
+        return activeWeekRepository
+                .findBySectionIdAndActiveTrueAndStartDateLessThanEqualOrderByStartDateDesc(sectionId, LocalDate.now());
+    }
+}

--- a/backend/src/main/java/edu/tcu/projectpulse/config/DataInitializer.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/config/DataInitializer.java
@@ -12,12 +12,17 @@ import edu.tcu.projectpulse.team.TeamRepository;
 import edu.tcu.projectpulse.user.User;
 import edu.tcu.projectpulse.user.UserRepository;
 import edu.tcu.projectpulse.user.UserRole;
+import edu.tcu.projectpulse.war.ActivityCategory;
+import edu.tcu.projectpulse.war.ActivityStatus;
+import edu.tcu.projectpulse.war.WarActivity;
+import edu.tcu.projectpulse.war.WarActivityRepository;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -31,28 +36,32 @@ public class DataInitializer implements CommandLineRunner {
     private final TeamRepository teamRepository;
     private final ActiveWeekRepository activeWeekRepository;
     private final RubricRepository rubricRepository;
+    private final WarActivityRepository warActivityRepository;
 
     public DataInitializer(UserRepository userRepository,
                            PasswordEncoder passwordEncoder,
                            SectionRepository sectionRepository,
                            TeamRepository teamRepository,
                            ActiveWeekRepository activeWeekRepository,
-                           RubricRepository rubricRepository) {
+                           RubricRepository rubricRepository,
+                           WarActivityRepository warActivityRepository) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.sectionRepository = sectionRepository;
         this.teamRepository = teamRepository;
         this.activeWeekRepository = activeWeekRepository;
         this.rubricRepository = rubricRepository;
+        this.warActivityRepository = warActivityRepository;
     }
 
     @Override
     public void run(String... args) {
         seedUsers();
         Section section = seedSection();
-        seedActiveWeek(section);
+        List<ActiveWeek> weeks = seedActiveWeeks(section);
         seedRubric(section);
         seedTeam(section);
+        seedWarActivities(weeks);
     }
 
     private void seedUsers() {
@@ -110,16 +119,91 @@ public class DataInitializer implements CommandLineRunner {
                 });
     }
 
-    private void seedActiveWeek(Section section) {
+    private List<ActiveWeek> seedActiveWeeks(Section section) {
         List<ActiveWeek> existing = activeWeekRepository.findBySectionIdOrderByStartDateAsc(section.getId());
-        if (existing.isEmpty()) {
+        if (!existing.isEmpty()) return existing;
+
+        LocalDate[][] ranges = {
+            { LocalDate.of(2026, 3, 30), LocalDate.of(2026, 4, 5)  },
+            { LocalDate.of(2026, 4, 6),  LocalDate.of(2026, 4, 12) },
+            { LocalDate.of(2026, 4, 13), LocalDate.of(2026, 4, 19) },
+            { LocalDate.of(2026, 4, 20), LocalDate.of(2026, 4, 26) },
+            { LocalDate.of(2026, 4, 27), LocalDate.of(2026, 5, 3)  },
+        };
+
+        List<ActiveWeek> weeks = new ArrayList<>();
+        for (LocalDate[] r : ranges) {
             ActiveWeek week = new ActiveWeek();
             week.setSectionId(section.getId());
-            week.setStartDate(LocalDate.of(2026, 4, 27));
-            week.setEndDate(LocalDate.of(2026, 5, 3));
+            week.setStartDate(r[0]);
+            week.setEndDate(r[1]);
             week.setActive(true);
-            activeWeekRepository.save(week);
+            weeks.add(activeWeekRepository.save(week));
         }
+        return weeks;
+    }
+
+    private void seedWarActivities(List<ActiveWeek> weeks) {
+        if (warActivityRepository.count() > 0 || weeks.size() < 5) return;
+
+        Integer jimothy  = userRepository.findByEmail("jimbo@tcu.edu").map(User::getId).orElse(null);
+        Integer bobert   = userRepository.findByEmail("bobinator@tcu.edu").map(User::getId).orElse(null);
+        Integer timantha = userRepository.findByEmail("timtam@tcu.edu").map(User::getId).orElse(null);
+        if (jimothy == null || bobert == null || timantha == null) return;
+
+        int w1 = weeks.get(0).getId().intValue();
+        int w2 = weeks.get(1).getId().intValue();
+        int w3 = weeks.get(2).getId().intValue();
+        int w4 = weeks.get(3).getId().intValue();
+        int w5 = weeks.get(4).getId().intValue();
+
+        warActivityRepository.saveAll(List.of(
+            // Week 1
+            war(jimothy,  w1, ActivityCategory.PLANNING,       "Sprint 1 planning and backlog grooming",                     2.0, 2.0,  ActivityStatus.DONE),
+            war(jimothy,  w1, ActivityCategory.DEVELOPMENT,    "Set up Spring Boot project structure and initial config",     6.0, 7.0,  ActivityStatus.DONE),
+            war(bobert,   w1, ActivityCategory.PLANNING,       "Sprint 1 kickoff and task assignment",                       2.0, 2.0,  ActivityStatus.DONE),
+            war(bobert,   w1, ActivityCategory.DESIGN,         "Wireframes for login and dashboard screens",                 5.0, 6.0,  ActivityStatus.DONE),
+            war(timantha, w1, ActivityCategory.PLANNING,       "Sprint 1 planning and user story refinement",                2.0, 2.0,  ActivityStatus.DONE),
+            war(timantha, w1, ActivityCategory.DOCUMENTATION,  "Draft requirements document and API spec",                   4.0, 5.0,  ActivityStatus.DONE),
+            // Week 2
+            war(jimothy,  w2, ActivityCategory.DEVELOPMENT,    "Implement JWT authentication and user registration",         8.0, 9.0,  ActivityStatus.DONE),
+            war(jimothy,  w2, ActivityCategory.TESTING,        "Unit tests for auth service",                                3.0, 3.0,  ActivityStatus.DONE),
+            war(bobert,   w2, ActivityCategory.DEVELOPMENT,    "Build login and registration Vue components",                6.0, 7.0,  ActivityStatus.DONE),
+            war(bobert,   w2, ActivityCategory.COMMUNICATION,  "Daily standups and code review sessions",                   2.0, 2.0,  ActivityStatus.DONE),
+            war(timantha, w2, ActivityCategory.DEVELOPMENT,    "Design and implement database schema",                       5.0, 6.0,  ActivityStatus.DONE),
+            war(timantha, w2, ActivityCategory.DOCUMENTATION,  "Write API documentation for auth endpoints",                 3.0, 3.0,  ActivityStatus.DONE),
+            // Week 3
+            war(jimothy,  w3, ActivityCategory.DEVELOPMENT,    "Implement section and team management endpoints",            7.0, 8.0,  ActivityStatus.DONE),
+            war(jimothy,  w3, ActivityCategory.BUGFIX,         "Fix CORS configuration for frontend integration",            2.0, 3.0,  ActivityStatus.DONE),
+            war(bobert,   w3, ActivityCategory.DEVELOPMENT,    "Build admin dashboard and navigation components",            8.0, 8.0,  ActivityStatus.DONE),
+            war(bobert,   w3, ActivityCategory.TESTING,        "Integration tests for frontend API calls",                   3.0, 4.0,  ActivityStatus.DONE),
+            war(timantha, w3, ActivityCategory.DEVELOPMENT,    "Implement peer evaluation service and rubric management",    6.0, 7.0,  ActivityStatus.DONE),
+            war(timantha, w3, ActivityCategory.PLANNING,       "Sprint 3 review and retrospective",                          2.0, 2.0,  ActivityStatus.DONE),
+            // Week 4
+            war(jimothy,  w4, ActivityCategory.DEVELOPMENT,    "Implement WAR activity CRUD endpoints",                     8.0, 9.0,  ActivityStatus.DONE),
+            war(jimothy,  w4, ActivityCategory.TESTING,        "Unit tests for WAR activity service",                       3.0, 3.0,  ActivityStatus.DONE),
+            war(bobert,   w4, ActivityCategory.DEVELOPMENT,    "Build WAR activity form and table components",               7.0, 8.0,  ActivityStatus.DONE),
+            war(bobert,   w4, ActivityCategory.BUGFIX,         "Fix week selector not loading on page refresh",              2.0, 2.5,  ActivityStatus.DONE),
+            war(timantha, w4, ActivityCategory.DEVELOPMENT,    "Implement WAR report service with non-submission flagging",  6.0, 6.0,  ActivityStatus.DONE),
+            war(timantha, w4, ActivityCategory.COMMUNICATION,  "Sprint 4 demo presentation to instructor",                  1.0, 1.0,  ActivityStatus.DONE),
+            // Week 5 — Jimothy and Timantha submitted; Bobert has not
+            war(jimothy,  w5, ActivityCategory.DEVELOPMENT,    "Add active week validation to activity submission",          4.0, 4.0,  ActivityStatus.DONE),
+            war(jimothy,  w5, ActivityCategory.PLANNING,       "Sprint 5 planning and backlog refinement",                   1.0, 1.0,  ActivityStatus.DONE),
+            war(timantha, w5, ActivityCategory.DEVELOPMENT,    "Build instructor WAR report view",                           5.0, null, ActivityStatus.IN_PROGRESS)
+        ));
+    }
+
+    private WarActivity war(Integer studentId, int weekId, ActivityCategory category,
+                            String description, double planned, Double actual, ActivityStatus status) {
+        WarActivity a = new WarActivity();
+        a.setStudentId(studentId);
+        a.setWeekId(weekId);
+        a.setCategory(category);
+        a.setDescription(description);
+        a.setPlannedHours(planned);
+        a.setActualHours(actual);
+        a.setStatus(status);
+        return a;
     }
 
     private void seedRubric(Section section) {

--- a/backend/src/main/java/edu/tcu/projectpulse/config/DataInitializer.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/config/DataInitializer.java
@@ -85,6 +85,18 @@ public class DataInitializer implements CommandLineRunner {
             student.addRole(UserRole.STUDENT);
             userRepository.save(student);
         }
+
+        if (userRepository.findByEmail("jimbo@tcu.edu").isEmpty()) {
+            User student = new User();
+            student.setEmail("jimbo@tcu.edu");
+            student.setFirstName("Jimbo");
+            student.setLastName("Student");
+            student.setPassword(passwordEncoder.encode("password123"));
+            student.setEnabled(true);
+            student.setAccountStatus(User.AccountStatus.ACTIVE);
+            student.addRole(UserRole.STUDENT);
+            userRepository.save(student);
+        }
     }
 
     private Section seedSection() {

--- a/backend/src/main/java/edu/tcu/projectpulse/config/SecurityConfig.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/config/SecurityConfig.java
@@ -42,10 +42,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOrigins(List.of(
-                "http://localhost:5173",
-                "http://localhost:5174"
-        ));
+        config.setAllowedOriginPatterns(List.of("http://localhost:*"));
 
         config.setAllowedMethods(List.of(
                 "GET",

--- a/backend/src/main/java/edu/tcu/projectpulse/report/WarReportService.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/report/WarReportService.java
@@ -1,6 +1,8 @@
 package edu.tcu.projectpulse.report;
 
-import edu.tcu.projectpulse.team.TeamMemberRepository;
+import edu.tcu.projectpulse.exception.ResourceNotFoundException;
+import edu.tcu.projectpulse.team.Team;
+import edu.tcu.projectpulse.team.TeamRepository;
 import edu.tcu.projectpulse.war.WarActivity;
 import edu.tcu.projectpulse.war.WarActivityRepository;
 import org.springframework.stereotype.Service;
@@ -13,20 +15,19 @@ import java.util.stream.Collectors;
 public class WarReportService {
 
     private final WarActivityRepository warActivityRepository;
-    private final TeamMemberRepository teamMemberRepository;
+    private final TeamRepository teamRepository;
 
     public WarReportService(WarActivityRepository warActivityRepository,
-                            TeamMemberRepository teamMemberRepository) {
+                            TeamRepository teamRepository) {
         this.warActivityRepository = warActivityRepository;
-        this.teamMemberRepository = teamMemberRepository;
+        this.teamRepository = teamRepository;
     }
 
     public Map<String, Object> buildTeamWarReport(Integer teamId, Integer weekId) {
-        List<Integer> teamMemberIds = teamMemberRepository.findByTeamId(teamId).stream()
-                .map(m -> m.getStudentId())
-                .collect(Collectors.toList());
+        Team team = teamRepository.findById(teamId.longValue())
+                .orElseThrow(() -> new ResourceNotFoundException("Team", "id", teamId));
 
-        List<Map<String, Object>> entries = teamMemberIds.stream()
+        List<Map<String, Object>> entries = team.getStudentIds().stream()
                 .map(studentId -> {
                     List<WarActivity> activities =
                             warActivityRepository.findByStudentIdAndWeekId(studentId, weekId);

--- a/backend/src/main/java/edu/tcu/projectpulse/report/WarReportService.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/report/WarReportService.java
@@ -1,5 +1,6 @@
 package edu.tcu.projectpulse.report;
 
+import edu.tcu.projectpulse.team.TeamMemberRepository;
 import edu.tcu.projectpulse.war.WarActivity;
 import edu.tcu.projectpulse.war.WarActivityRepository;
 import org.springframework.stereotype.Service;
@@ -12,14 +13,18 @@ import java.util.stream.Collectors;
 public class WarReportService {
 
     private final WarActivityRepository warActivityRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
-    public WarReportService(WarActivityRepository warActivityRepository) {
+    public WarReportService(WarActivityRepository warActivityRepository,
+                            TeamMemberRepository teamMemberRepository) {
         this.warActivityRepository = warActivityRepository;
+        this.teamMemberRepository = teamMemberRepository;
     }
 
     public Map<String, Object> buildTeamWarReport(Integer teamId, Integer weekId) {
-        // TODO: replace stub with real team member lookup (needs TeamMemberRepository)
-        List<Integer> teamMemberIds = List.of();
+        List<Integer> teamMemberIds = teamMemberRepository.findByTeamId(teamId).stream()
+                .map(m -> m.getStudentId())
+                .collect(Collectors.toList());
 
         List<Map<String, Object>> entries = teamMemberIds.stream()
                 .map(studentId -> {

--- a/backend/src/main/java/edu/tcu/projectpulse/team/TeamMemberRepository.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/team/TeamMemberRepository.java
@@ -2,8 +2,15 @@ package edu.tcu.projectpulse.team;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Integer> {
 
     boolean existsByTeamIdAndStudentId(Integer teamId, Integer studentId);
+
+    Optional<TeamMember> findByStudentId(Integer studentId);
+
+    List<TeamMember> findByTeamId(Integer teamId);
 
 }

--- a/backend/src/main/java/edu/tcu/projectpulse/war/WarActivityService.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/war/WarActivityService.java
@@ -1,19 +1,26 @@
 package edu.tcu.projectpulse.war;
 
+import edu.tcu.projectpulse.activeweek.ActiveWeek;
+import edu.tcu.projectpulse.activeweek.ActiveWeekRepository;
 import edu.tcu.projectpulse.exception.ResourceNotFoundException;
+import edu.tcu.projectpulse.exception.ValidationException;
 import edu.tcu.projectpulse.war.dto.WarActivityRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
 public class WarActivityService {
 
     private final WarActivityRepository warActivityRepository;
+    private final ActiveWeekRepository activeWeekRepository;
 
-    public WarActivityService(WarActivityRepository warActivityRepository) {
+    public WarActivityService(WarActivityRepository warActivityRepository,
+                               ActiveWeekRepository activeWeekRepository) {
         this.warActivityRepository = warActivityRepository;
+        this.activeWeekRepository = activeWeekRepository;
     }
 
     public List<WarActivity> getActivities(Integer studentId, Integer weekId) {
@@ -22,7 +29,15 @@ public class WarActivityService {
 
     @Transactional
     public WarActivity add(Integer studentId, WarActivityRequest request) {
-        // TODO: validate weekId is an active week and not in the future (needs ActiveWeekRepository)
+        ActiveWeek week = activeWeekRepository.findById(request.getWeekId())
+                .orElseThrow(() -> new ResourceNotFoundException("ActiveWeek", "id", request.getWeekId()));
+
+        if (!week.isActive()) {
+            throw new ValidationException("Week " + request.getWeekId() + " is not an active week");
+        }
+        if (week.getWeekStart().isAfter(LocalDate.now())) {
+            throw new ValidationException("Cannot submit activities for a future week");
+        }
 
         WarActivity activity = new WarActivity();
         activity.setStudentId(studentId);

--- a/backend/src/main/java/edu/tcu/projectpulse/war/WarActivityService.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/war/WarActivityService.java
@@ -29,13 +29,13 @@ public class WarActivityService {
 
     @Transactional
     public WarActivity add(Integer studentId, WarActivityRequest request) {
-        ActiveWeek week = activeWeekRepository.findById(request.getWeekId())
+        ActiveWeek week = activeWeekRepository.findById(request.getWeekId().longValue())
                 .orElseThrow(() -> new ResourceNotFoundException("ActiveWeek", "id", request.getWeekId()));
 
         if (!week.isActive()) {
             throw new ValidationException("Week " + request.getWeekId() + " is not an active week");
         }
-        if (week.getWeekStart().isAfter(LocalDate.now())) {
+        if (week.getStartDate().isAfter(LocalDate.now())) {
             throw new ValidationException("Cannot submit activities for a future week");
         }
 

--- a/backend/src/test/java/edu/tcu/projectpulse/report/WarReportServiceTest.java
+++ b/backend/src/test/java/edu/tcu/projectpulse/report/WarReportServiceTest.java
@@ -1,7 +1,7 @@
 package edu.tcu.projectpulse.report;
 
-import edu.tcu.projectpulse.team.TeamMember;
-import edu.tcu.projectpulse.team.TeamMemberRepository;
+import edu.tcu.projectpulse.team.Team;
+import edu.tcu.projectpulse.team.TeamRepository;
 import edu.tcu.projectpulse.war.WarActivity;
 import edu.tcu.projectpulse.war.WarActivityRepository;
 import org.junit.jupiter.api.Test;
@@ -12,6 +12,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -23,16 +25,15 @@ class WarReportServiceTest {
     private WarActivityRepository warActivityRepository;
 
     @Mock
-    private TeamMemberRepository teamMemberRepository;
+    private TeamRepository teamRepository;
 
     @InjectMocks
     private WarReportService warReportService;
 
-    private TeamMember member(Integer teamId, Integer studentId) {
-        TeamMember m = new TeamMember();
-        m.setTeamId(teamId);
-        m.setStudentId(studentId);
-        return m;
+    private Team team(Integer id, Set<Integer> studentIds) {
+        Team t = new Team();
+        t.setStudentIds(studentIds);
+        return t;
     }
 
     private WarActivity activity(Integer studentId, Integer weekId) {
@@ -45,10 +46,7 @@ class WarReportServiceTest {
     @Test
     @SuppressWarnings("unchecked")
     void should_FlagNonSubmitter_When_StudentHasNoActivities() {
-        given(teamMemberRepository.findByTeamId(1)).willReturn(List.of(
-                member(1, 10),
-                member(1, 11)
-        ));
+        given(teamRepository.findById(1L)).willReturn(Optional.of(team(1, Set.of(10, 11))));
         given(warActivityRepository.findByStudentIdAndWeekId(10, 5)).willReturn(List.of(activity(10, 5)));
         given(warActivityRepository.findByStudentIdAndWeekId(11, 5)).willReturn(List.of());
 
@@ -68,7 +66,7 @@ class WarReportServiceTest {
 
     @Test
     void should_ReturnEmptyEntries_When_TeamHasNoMembers() {
-        given(teamMemberRepository.findByTeamId(99)).willReturn(List.of());
+        given(teamRepository.findById(99L)).willReturn(Optional.of(team(99, Set.of())));
 
         Map<String, Object> report = warReportService.buildTeamWarReport(99, 1);
 
@@ -80,10 +78,7 @@ class WarReportServiceTest {
     @Test
     @SuppressWarnings("unchecked")
     void should_MarkAllSubmitted_When_AllMembersHaveActivities() {
-        given(teamMemberRepository.findByTeamId(2)).willReturn(List.of(
-                member(2, 20),
-                member(2, 21)
-        ));
+        given(teamRepository.findById(2L)).willReturn(Optional.of(team(2, Set.of(20, 21))));
         given(warActivityRepository.findByStudentIdAndWeekId(20, 3)).willReturn(List.of(activity(20, 3)));
         given(warActivityRepository.findByStudentIdAndWeekId(21, 3)).willReturn(List.of(activity(21, 3)));
 

--- a/backend/src/test/java/edu/tcu/projectpulse/report/WarReportServiceTest.java
+++ b/backend/src/test/java/edu/tcu/projectpulse/report/WarReportServiceTest.java
@@ -1,0 +1,95 @@
+package edu.tcu.projectpulse.report;
+
+import edu.tcu.projectpulse.team.TeamMember;
+import edu.tcu.projectpulse.team.TeamMemberRepository;
+import edu.tcu.projectpulse.war.WarActivity;
+import edu.tcu.projectpulse.war.WarActivityRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class WarReportServiceTest {
+
+    @Mock
+    private WarActivityRepository warActivityRepository;
+
+    @Mock
+    private TeamMemberRepository teamMemberRepository;
+
+    @InjectMocks
+    private WarReportService warReportService;
+
+    private TeamMember member(Integer teamId, Integer studentId) {
+        TeamMember m = new TeamMember();
+        m.setTeamId(teamId);
+        m.setStudentId(studentId);
+        return m;
+    }
+
+    private WarActivity activity(Integer studentId, Integer weekId) {
+        WarActivity a = new WarActivity();
+        a.setStudentId(studentId);
+        a.setWeekId(weekId);
+        return a;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void should_FlagNonSubmitter_When_StudentHasNoActivities() {
+        given(teamMemberRepository.findByTeamId(1)).willReturn(List.of(
+                member(1, 10),
+                member(1, 11)
+        ));
+        given(warActivityRepository.findByStudentIdAndWeekId(10, 5)).willReturn(List.of(activity(10, 5)));
+        given(warActivityRepository.findByStudentIdAndWeekId(11, 5)).willReturn(List.of());
+
+        Map<String, Object> report = warReportService.buildTeamWarReport(1, 5);
+
+        List<Map<String, Object>> entries = (List<Map<String, Object>>) report.get("entries");
+        assertThat(entries).hasSize(2);
+
+        Map<String, Object> submitter = entries.stream()
+                .filter(e -> e.get("studentId").equals(10)).findFirst().orElseThrow();
+        assertThat(submitter.get("submitted")).isEqualTo(true);
+
+        Map<String, Object> nonSubmitter = entries.stream()
+                .filter(e -> e.get("studentId").equals(11)).findFirst().orElseThrow();
+        assertThat(nonSubmitter.get("submitted")).isEqualTo(false);
+    }
+
+    @Test
+    void should_ReturnEmptyEntries_When_TeamHasNoMembers() {
+        given(teamMemberRepository.findByTeamId(99)).willReturn(List.of());
+
+        Map<String, Object> report = warReportService.buildTeamWarReport(99, 1);
+
+        assertThat(report.get("teamId")).isEqualTo(99);
+        assertThat(report.get("weekId")).isEqualTo(1);
+        assertThat((List<?>) report.get("entries")).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void should_MarkAllSubmitted_When_AllMembersHaveActivities() {
+        given(teamMemberRepository.findByTeamId(2)).willReturn(List.of(
+                member(2, 20),
+                member(2, 21)
+        ));
+        given(warActivityRepository.findByStudentIdAndWeekId(20, 3)).willReturn(List.of(activity(20, 3)));
+        given(warActivityRepository.findByStudentIdAndWeekId(21, 3)).willReturn(List.of(activity(21, 3)));
+
+        Map<String, Object> report = warReportService.buildTeamWarReport(2, 3);
+
+        List<Map<String, Object>> entries = (List<Map<String, Object>>) report.get("entries");
+        assertThat(entries).allMatch(e -> (Boolean) e.get("submitted"));
+    }
+}

--- a/backend/src/test/java/edu/tcu/projectpulse/war/WarActivityServiceTest.java
+++ b/backend/src/test/java/edu/tcu/projectpulse/war/WarActivityServiceTest.java
@@ -1,6 +1,9 @@
 package edu.tcu.projectpulse.war;
 
+import edu.tcu.projectpulse.activeweek.ActiveWeek;
+import edu.tcu.projectpulse.activeweek.ActiveWeekRepository;
 import edu.tcu.projectpulse.exception.ResourceNotFoundException;
+import edu.tcu.projectpulse.exception.ValidationException;
 import edu.tcu.projectpulse.war.dto.WarActivityRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +13,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,6 +28,9 @@ class WarActivityServiceTest {
 
     @Mock
     private WarActivityRepository warActivityRepository;
+
+    @Mock
+    private ActiveWeekRepository activeWeekRepository;
 
     @InjectMocks
     private WarActivityService warActivityService;
@@ -41,8 +48,17 @@ class WarActivityServiceTest {
         request.setStatus(ActivityStatus.DONE);
     }
 
+    private ActiveWeek activeWeek(boolean active, LocalDate weekStart) {
+        ActiveWeek week = new ActiveWeek();
+        week.setActive(active);
+        week.setWeekStart(weekStart);
+        return week;
+    }
+
     @Test
-    void should_AddActivity_When_RequestIsValid() {
+    void should_AddActivity_When_WeekIsActiveAndNotFuture() {
+        given(activeWeekRepository.findById(1))
+                .willReturn(Optional.of(activeWeek(true, LocalDate.now().minusDays(1))));
         given(warActivityRepository.save(any(WarActivity.class))).willAnswer(inv -> inv.getArgument(0));
 
         warActivityService.add(1, request);
@@ -124,5 +140,33 @@ class WarActivityServiceTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getStudentId()).isEqualTo(1);
+    }
+
+    @Test
+    void should_ThrowException_When_WeekIdNotFound() {
+        given(activeWeekRepository.findById(1)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> warActivityService.add(1, request))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void should_ThrowException_When_WeekIsNotActive() {
+        given(activeWeekRepository.findById(1))
+                .willReturn(Optional.of(activeWeek(false, LocalDate.now().minusDays(1))));
+
+        assertThatThrownBy(() -> warActivityService.add(1, request))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("not an active week");
+    }
+
+    @Test
+    void should_ThrowException_When_WeekIsInFuture() {
+        given(activeWeekRepository.findById(1))
+                .willReturn(Optional.of(activeWeek(true, LocalDate.now().plusDays(7))));
+
+        assertThatThrownBy(() -> warActivityService.add(1, request))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("future week");
     }
 }

--- a/backend/src/test/java/edu/tcu/projectpulse/war/WarActivityServiceTest.java
+++ b/backend/src/test/java/edu/tcu/projectpulse/war/WarActivityServiceTest.java
@@ -48,16 +48,16 @@ class WarActivityServiceTest {
         request.setStatus(ActivityStatus.DONE);
     }
 
-    private ActiveWeek activeWeek(boolean active, LocalDate weekStart) {
+    private ActiveWeek activeWeek(boolean active, LocalDate startDate) {
         ActiveWeek week = new ActiveWeek();
         week.setActive(active);
-        week.setWeekStart(weekStart);
+        week.setStartDate(startDate);
         return week;
     }
 
     @Test
     void should_AddActivity_When_WeekIsActiveAndNotFuture() {
-        given(activeWeekRepository.findById(1))
+        given(activeWeekRepository.findById(1L))
                 .willReturn(Optional.of(activeWeek(true, LocalDate.now().minusDays(1))));
         given(warActivityRepository.save(any(WarActivity.class))).willAnswer(inv -> inv.getArgument(0));
 
@@ -144,7 +144,7 @@ class WarActivityServiceTest {
 
     @Test
     void should_ThrowException_When_WeekIdNotFound() {
-        given(activeWeekRepository.findById(1)).willReturn(Optional.empty());
+        given(activeWeekRepository.findById(1L)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> warActivityService.add(1, request))
                 .isInstanceOf(ResourceNotFoundException.class);
@@ -152,7 +152,7 @@ class WarActivityServiceTest {
 
     @Test
     void should_ThrowException_When_WeekIsNotActive() {
-        given(activeWeekRepository.findById(1))
+        given(activeWeekRepository.findById(1L))
                 .willReturn(Optional.of(activeWeek(false, LocalDate.now().minusDays(1))));
 
         assertThatThrownBy(() -> warActivityService.add(1, request))
@@ -162,7 +162,7 @@ class WarActivityServiceTest {
 
     @Test
     void should_ThrowException_When_WeekIsInFuture() {
-        given(activeWeekRepository.findById(1))
+        given(activeWeekRepository.findById(1L))
                 .willReturn(Optional.of(activeWeek(true, LocalDate.now().plusDays(7))));
 
         assertThatThrownBy(() -> warActivityService.add(1, request))

--- a/frontend/src/api/activeWeeks.js
+++ b/frontend/src/api/activeWeeks.js
@@ -7,3 +7,7 @@ export function getActiveWeeksBySection(sectionId) {
 export function saveActiveWeeksBySection(sectionId, weeks) {
   return api.post(`/api/active-weeks/section/${sectionId}`, weeks)
 }
+
+export function getActiveWeeksForSection(sectionId) {
+  return api.get(`/api/active-weeks/section/${sectionId}/available`)
+}

--- a/frontend/src/api/war.js
+++ b/frontend/src/api/war.js
@@ -1,5 +1,9 @@
 import api from '../plugins/axios'
 
+export function getTeams() {
+  return api.get('/api/teams')
+}
+
 export function getMyTeam() {
   return api.get('/api/teams/my-team')
 }

--- a/frontend/src/api/war.js
+++ b/frontend/src/api/war.js
@@ -1,5 +1,9 @@
 import api from '../plugins/axios'
 
+export function getMyTeam() {
+  return api.get('/api/teams/my-team')
+}
+
 export function getActivities(weekId) {
   return api.get('/api/war-activities', { params: { weekId } })
 }

--- a/frontend/src/components/WarActivityForm.vue
+++ b/frontend/src/components/WarActivityForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card variant="outlined" rounded="lg">
+  <v-card rounded="lg">
     <v-card-title class="pa-4 pb-2">{{ activity ? 'Edit Activity' : 'Add Activity' }}</v-card-title>
     <v-card-text class="pa-4 pt-2">
       <v-alert v-if="error" type="error" variant="tonal" class="mb-4" closable @click:close="error = ''">

--- a/frontend/src/components/WarActivityTable.vue
+++ b/frontend/src/components/WarActivityTable.vue
@@ -4,10 +4,10 @@
       <tr>
         <th>Category</th>
         <th>Description</th>
-        <th>Planned Hrs</th>
-        <th>Actual Hrs</th>
+        <th>Planned Hours</th>
+        <th>Actual Hours</th>
         <th>Status</th>
-        <th></th>
+        <th style="width: 96px">Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -17,12 +17,16 @@
         </td>
       </tr>
       <tr v-for="activity in activities" :key="activity.id">
-        <td>{{ categoryLabel(activity.category) }}</td>
+        <td>
+          <v-chip :color="categoryColor(activity.category)" size="small" variant="tonal">
+            {{ categoryLabel(activity.category) }}
+          </v-chip>
+        </td>
         <td>{{ activity.description }}</td>
         <td>{{ activity.plannedHours }}</td>
         <td>{{ activity.actualHours ?? '—' }}</td>
         <td>{{ statusLabel(activity.status) }}</td>
-        <td>
+        <td style="width: 96px; white-space: nowrap">
           <v-btn icon size="small" variant="text" @click="$emit('edit', activity)">
             <v-icon icon="mdi-pencil-outline" />
           </v-btn>
@@ -49,6 +53,20 @@ const CATEGORY_LABELS = {
   SUPPORT: 'Support', MISCELLANEOUS: 'Miscellaneous',
 }
 
+const CATEGORY_COLORS = {
+  DEVELOPMENT: 'blue',
+  TESTING: 'teal',
+  BUGFIX: 'red',
+  COMMUNICATION: 'cyan',
+  DOCUMENTATION: 'purple',
+  DESIGN: 'pink',
+  PLANNING: 'indigo',
+  LEARNING: 'green',
+  DEPLOYMENT: 'orange',
+  SUPPORT: 'amber',
+  MISCELLANEOUS: 'grey',
+}
+
 const STATUS_LABELS = {
   IN_PROGRESS: 'In Progress',
   UNDER_TESTING: 'Under Testing',
@@ -56,5 +74,6 @@ const STATUS_LABELS = {
 }
 
 function categoryLabel(val) { return CATEGORY_LABELS[val] ?? val }
+function categoryColor(val) { return CATEGORY_COLORS[val] ?? 'grey' }
 function statusLabel(val) { return STATUS_LABELS[val] ?? val }
 </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -23,6 +23,7 @@ import ActiveWeeksView from '../views/admin/ActiveWeeksView.vue'
 import InviteStudentView from '../views/admin/InviteStudentView.vue'
 import StudentsView from '../views/admin/StudentsView.vue'
 import TeamStudentsView from '../views/admin/TeamStudentsView.vue'
+import TeamWarReportView from '../views/instructor/TeamWarReportView.vue'
 
 const PlaceholderView = {
   template: `
@@ -78,7 +79,7 @@ const routes = [
 
       { path: 'students', component: StudentsView },
       { path: 'students/invite', component: InviteStudentView },
-      { path: 'reports', component: PlaceholderView }
+      { path: 'reports', component: TeamWarReportView }
     ]
   }
 ]

--- a/frontend/src/views/instructor/TeamWarReportView.vue
+++ b/frontend/src/views/instructor/TeamWarReportView.vue
@@ -1,0 +1,173 @@
+<template>
+  <div>
+    <div class="text-h5 font-weight-bold mb-1">Team WAR Report</div>
+    <div class="text-body-2 text-medium-emphasis mb-6">View a team's weekly activity report.</div>
+
+    <div class="d-flex ga-4 mb-6 flex-wrap">
+      <v-select
+        v-model="selectedTeamId"
+        :items="teams"
+        item-title="name"
+        item-value="id"
+        label="Select Team"
+        variant="outlined"
+        style="max-width: 280px"
+        :loading="loadingTeams"
+        :disabled="loadingTeams"
+        @update:model-value="onTeamChange"
+      />
+
+      <v-select
+        v-model="selectedWeekId"
+        :items="weeks"
+        item-title="label"
+        item-value="id"
+        label="Select Week"
+        variant="outlined"
+        style="max-width: 280px"
+        :loading="loadingWeeks"
+        :disabled="loadingWeeks || !selectedTeamId"
+        @update:model-value="loadReport"
+      />
+    </div>
+
+    <v-alert v-if="error" type="error" variant="tonal" class="mb-4">{{ error }}</v-alert>
+
+    <div v-if="loading" class="d-flex justify-center py-8">
+      <v-progress-circular indeterminate color="primary" />
+    </div>
+
+    <template v-else-if="report">
+      <div v-if="report.entries.length === 0" class="text-medium-emphasis text-body-2">
+        No team members found.
+      </div>
+
+      <div v-for="entry in report.entries" :key="entry.studentId" class="mb-6">
+        <div class="d-flex align-center ga-2 mb-2">
+          <div class="text-h6 font-weight-medium">Student #{{ entry.studentId }}</div>
+          <v-chip v-if="!entry.submitted" color="error" size="small">Did not submit</v-chip>
+        </div>
+
+        <v-table v-if="entry.submitted">
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Description</th>
+              <th>Planned Hrs</th>
+              <th>Actual Hrs</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="activity in entry.activities" :key="activity.id">
+              <td>{{ categoryLabel(activity.category) }}</td>
+              <td>{{ activity.description }}</td>
+              <td>{{ activity.plannedHours }}</td>
+              <td>{{ activity.actualHours ?? '—' }}</td>
+              <td>{{ statusLabel(activity.status) }}</td>
+            </tr>
+          </tbody>
+        </v-table>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { getTeams, getTeamWarReport } from '../../api/war'
+import { getActiveWeeksForSection } from '../../api/activeWeeks'
+
+const CATEGORY_LABELS = {
+  DEVELOPMENT: 'Development', TESTING: 'Testing', BUGFIX: 'Bug Fix',
+  COMMUNICATION: 'Communication', DOCUMENTATION: 'Documentation', DESIGN: 'Design',
+  PLANNING: 'Planning', LEARNING: 'Learning', DEPLOYMENT: 'Deployment',
+  SUPPORT: 'Support', MISCELLANEOUS: 'Miscellaneous',
+}
+
+const STATUS_LABELS = {
+  IN_PROGRESS: 'In Progress',
+  UNDER_TESTING: 'Under Testing',
+  DONE: 'Done',
+}
+
+function categoryLabel(val) { return CATEGORY_LABELS[val] ?? val }
+function statusLabel(val) { return STATUS_LABELS[val] ?? val }
+
+function formatWeekLabel(weekStart) {
+  const start = new Date(weekStart + 'T00:00:00')
+  const end = new Date(start)
+  end.setDate(end.getDate() + 6)
+  const fmt = { month: 'short', day: 'numeric' }
+  return `${start.toLocaleDateString('en-US', fmt)} – ${end.toLocaleDateString('en-US', fmt)}`
+}
+
+const teams = ref([])
+const weeks = ref([])
+const loadingTeams = ref(false)
+const loadingWeeks = ref(false)
+const selectedTeamId = ref(null)
+const selectedWeekId = ref(null)
+const report = ref(null)
+const loading = ref(false)
+const error = ref('')
+
+onMounted(async () => {
+  loadingTeams.value = true
+  error.value = ''
+  try {
+    const res = await getTeams()
+    teams.value = res.data
+    if (teams.value.length > 0) {
+      selectedTeamId.value = teams.value[0].id
+      await loadWeeksForTeam(teams.value[0])
+    }
+  } catch {
+    error.value = 'Failed to load teams.'
+  } finally {
+    loadingTeams.value = false
+  }
+})
+
+async function onTeamChange(teamId) {
+  selectedWeekId.value = null
+  weeks.value = []
+  report.value = null
+  const team = teams.value.find(t => t.id === teamId)
+  if (team) await loadWeeksForTeam(team)
+}
+
+async function loadWeeksForTeam(team) {
+  loadingWeeks.value = true
+  error.value = ''
+  try {
+    const res = await getActiveWeeksForSection(team.sectionId)
+    weeks.value = res.data.data.map(w => ({
+      id: w.id,
+      label: formatWeekLabel(w.weekStart),
+    }))
+    if (weeks.value.length > 0) {
+      selectedWeekId.value = weeks.value[0].id
+      await loadReport()
+    }
+  } catch {
+    error.value = 'Failed to load weeks.'
+  } finally {
+    loadingWeeks.value = false
+  }
+}
+
+async function loadReport() {
+  if (!selectedTeamId.value || !selectedWeekId.value) return
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await getTeamWarReport(selectedTeamId.value, selectedWeekId.value)
+    report.value = res.data.data
+  } catch (err) {
+    error.value = err.response?.data?.message ?? 'Failed to load report.'
+  } finally {
+    loading.value = false
+  }
+}
+</script>

--- a/frontend/src/views/instructor/TeamWarReportView.vue
+++ b/frontend/src/views/instructor/TeamWarReportView.vue
@@ -144,7 +144,7 @@ async function loadWeeksForTeam(team) {
     const res = await getActiveWeeksForSection(team.sectionId)
     weeks.value = res.data.data.map(w => ({
       id: w.id,
-      label: formatWeekLabel(w.weekStart),
+      label: formatWeekLabel(w.startDate),
     }))
     if (weeks.value.length > 0) {
       selectedWeekId.value = weeks.value[0].id

--- a/frontend/src/views/student/WarReportView.vue
+++ b/frontend/src/views/student/WarReportView.vue
@@ -5,13 +5,15 @@
 
     <v-select
       v-model="selectedWeekId"
-      :items="MOCK_WEEKS"
+      :items="weeks"
       item-title="label"
       item-value="id"
       label="Select Week"
       variant="outlined"
       style="max-width: 320px"
       class="mb-6"
+      :loading="loadingWeeks"
+      :disabled="loadingWeeks"
       @update:model-value="loadReport"
     />
 
@@ -59,15 +61,8 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import { getTeamWarReport } from '../../api/war'
-
-const MOCK_WEEKS = [
-  { id: 1, label: 'Week 1 (Jan 13 – Jan 19)' },
-  { id: 2, label: 'Week 2 (Jan 20 – Jan 26)' },
-  { id: 3, label: 'Week 3 (Jan 27 – Feb 2)' },
-]
-
-const MOCK_TEAM_ID = 1
+import { getMyTeam, getTeamWarReport } from '../../api/war'
+import { getActiveWeeksForSection } from '../../api/activeWeeks'
 
 const CATEGORY_LABELS = {
   DEVELOPMENT: 'Development', TESTING: 'Testing', BUGFIX: 'Bug Fix',
@@ -85,18 +80,50 @@ const STATUS_LABELS = {
 function categoryLabel(val) { return CATEGORY_LABELS[val] ?? val }
 function statusLabel(val) { return STATUS_LABELS[val] ?? val }
 
-const selectedWeekId = ref(MOCK_WEEKS[0].id)
+function formatWeekLabel(weekStart) {
+  const start = new Date(weekStart + 'T00:00:00')
+  const end = new Date(start)
+  end.setDate(end.getDate() + 6)
+  const fmt = { month: 'short', day: 'numeric' }
+  return `${start.toLocaleDateString('en-US', fmt)} – ${end.toLocaleDateString('en-US', fmt)}`
+}
+
+const selectedWeekId = ref(null)
+const weeks = ref([])
+const loadingWeeks = ref(false)
+const teamId = ref(null)
 const report = ref(null)
-const loading = ref(true)
+const loading = ref(false)
 const error = ref('')
 
-onMounted(loadReport)
+onMounted(async () => {
+  loadingWeeks.value = true
+  error.value = ''
+  try {
+    const teamRes = await getMyTeam()
+    teamId.value = teamRes.data.data.teamId
+    const sectionId = teamRes.data.data.sectionId
+    const weeksRes = await getActiveWeeksForSection(sectionId)
+    weeks.value = weeksRes.data.data.map(w => ({
+      id: w.id,
+      label: formatWeekLabel(w.weekStart),
+    }))
+    if (weeks.value.length > 0) {
+      selectedWeekId.value = weeks.value[0].id
+      await loadReport()
+    }
+  } catch {
+    error.value = 'Failed to load weeks.'
+  } finally {
+    loadingWeeks.value = false
+  }
+})
 
 async function loadReport() {
   loading.value = true
   error.value = ''
   try {
-    const response = await getTeamWarReport(MOCK_TEAM_ID, selectedWeekId.value)
+    const response = await getTeamWarReport(teamId.value, selectedWeekId.value)
     report.value = response.data.data
   } catch (err) {
     error.value = err.response?.data?.message ?? 'Failed to load report.'

--- a/frontend/src/views/student/WarReportView.vue
+++ b/frontend/src/views/student/WarReportView.vue
@@ -106,7 +106,7 @@ onMounted(async () => {
     const weeksRes = await getActiveWeeksForSection(sectionId)
     weeks.value = weeksRes.data.data.map(w => ({
       id: w.id,
-      label: formatWeekLabel(w.weekStart),
+      label: formatWeekLabel(w.startDate),
     }))
     if (weeks.value.length > 0) {
       selectedWeekId.value = weeks.value[0].id

--- a/frontend/src/views/student/WarView.vue
+++ b/frontend/src/views/student/WarView.vue
@@ -7,13 +7,15 @@
 
     <v-select
       v-model="selectedWeekId"
-      :items="MOCK_WEEKS"
+      :items="weeks"
       item-title="label"
       item-value="id"
       label="Select Week"
       variant="outlined"
       style="max-width: 320px"
       class="mb-6"
+      :loading="loadingWeeks"
+      :disabled="loadingWeeks"
       @update:model-value="loadActivities"
     />
 
@@ -56,17 +58,14 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import { getActivities, deleteActivity } from '../../api/war'
+import { getMyTeam, getActivities, deleteActivity } from '../../api/war'
+import { getActiveWeeksForSection } from '../../api/activeWeeks'
 import WarActivityTable from '../../components/WarActivityTable.vue'
 import WarActivityForm from '../../components/WarActivityForm.vue'
 
-const MOCK_WEEKS = [
-  { id: 1, label: 'Week 1 (Jan 13 – Jan 19)' },
-  { id: 2, label: 'Week 2 (Jan 20 – Jan 26)' },
-  { id: 3, label: 'Week 3 (Jan 27 – Feb 2)' },
-]
-
-const selectedWeekId = ref(MOCK_WEEKS[0].id)
+const selectedWeekId = ref(null)
+const weeks = ref([])
+const loadingWeeks = ref(false)
 const activities = ref([])
 const error = ref('')
 
@@ -77,7 +76,39 @@ const deleteDialogOpen = ref(false)
 const deletingActivity = ref(null)
 const deleting = ref(false)
 
-onMounted(loadActivities)
+onMounted(async () => {
+  await loadWeeks()
+  if (selectedWeekId.value) loadActivities()
+})
+
+async function loadWeeks() {
+  loadingWeeks.value = true
+  error.value = ''
+  try {
+    const teamRes = await getMyTeam()
+    const sectionId = teamRes.data.data.sectionId
+    const weeksRes = await getActiveWeeksForSection(sectionId)
+    weeks.value = weeksRes.data.data.map(w => ({
+      id: w.id,
+      label: formatWeekLabel(w.startDate),
+    }))
+    if (weeks.value.length > 0) {
+      selectedWeekId.value = weeks.value[0].id
+    }
+  } catch {
+    error.value = 'Failed to load weeks.'
+  } finally {
+    loadingWeeks.value = false
+  }
+}
+
+function formatWeekLabel(weekStart) {
+  const start = new Date(weekStart + 'T00:00:00')
+  const end = new Date(start)
+  end.setDate(end.getDate() + 6)
+  const fmt = { month: 'short', day: 'numeric' }
+  return `${start.toLocaleDateString('en-US', fmt)} – ${end.toLocaleDateString('en-US', fmt)}`
+}
 
 async function loadActivities() {
   error.value = ''


### PR DESCRIPTION
## Summary

### UC-27 — Student can add/edit/delete WAR activities for active weeks

- **Active week validation**: `WarActivityService.add()` now rejects submissions for weeks that don't exist, are inactive, or have a start date in the future
- **Student WAR view** (`WarView.vue`): fetches the student's team → section → available active weeks from the API; week selector only shows weeks that are active and not in the future
- **Add/edit/delete activities** wired to the backend; form and table components built out with category chips, color coding, and a fixed actions column

### UC-32 — Instructor and student can generate a WAR report for a team

- **`WarReportService`**: builds a per-student activity report for a given team and week; flags any student who has not submitted
- **Student WAR report view** (`WarReportView.vue`): loads the student's team, fetches available weeks, and displays the full team report
- **Instructor WAR report view** (`TeamWarReportView.vue`): team and week selectors; shows each student's activities with a "Did not submit" badge for non-submitters; wired to `/reports` route

### Infrastructure / fixes

- `ActiveWeekService` + `/section/{sectionId}/available` endpoint: returns only active, non-future weeks for a given section (used by both student and instructor views)
- CORS config updated to `setAllowedOriginPatterns("http://localhost:*")` to handle Vite's auto-incrementing dev ports
- Add activity modal: removed `variant="outlined"` from `v-card` to fix transparent background

## Test plan

- [x] Log in as a student and navigate to Weekly Activity Report
- [x] Confirm week selector only shows active, non-future weeks
- [x] Add, edit, and delete activities; verify validation rejects future/inactive weeks
- [x] View the student WAR report and confirm your team's submissions appear
- [ ] Log in as an instructor, navigate to Reports, select a team and week, and verify the report flags any student with no activities