### PR TITLE
Feat/deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,69 @@
+# Required GitHub secrets:
+#   AZURE_WEBAPP_PUBLISH_PROFILE   — download from Azure Portal > App Service > Get publish profile
+#   AZURE_STATIC_WEB_APPS_API_TOKEN — from Azure Portal > Static Web App > Manage deployment token
+#
+# Required GitHub repository variables (Settings > Variables > Actions):
+#   AZURE_WEBAPP_NAME   — your App Service name (e.g. project-pulse-api)
+#   VITE_API_BASE_URL   — full backend URL (e.g. https://project-pulse-api.azurewebsites.net)
+
+name: Deploy to Azure
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  deploy-backend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+          cache: maven
+
+      - name: Build JAR
+        run: ./mvnw -B package -DskipTests --file backend/pom.xml
+
+      - name: Deploy to Azure App Service
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ vars.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: backend/target/*.jar
+
+  deploy-frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Build
+        run: npm run build
+        working-directory: frontend
+        env:
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+
+      - name: Deploy to Azure Static Web Apps
+        uses: azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "frontend"
+          output_location: "dist"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM maven:3.9-eclipse-temurin-17-alpine AS build
+WORKDIR /app
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+COPY src/ ./src/
+RUN mvn package -DskipTests -B
+
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/src/main/java/edu/tcu/projectpulse/config/SecurityConfig.java
+++ b/backend/src/main/java/edu/tcu/projectpulse/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package edu.tcu.projectpulse.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -13,11 +14,15 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
 @EnableMethodSecurity
 public class SecurityConfig {
+
+    @Value("${cors.allowed-origins:http://localhost:5173,http://localhost:4173}")
+    private String allowedOrigins;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -42,7 +47,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOriginPatterns(List.of("http://localhost:*"));
+        config.setAllowedOriginPatterns(Arrays.asList(allowedOrigins.split(",")));
 
         config.setAllowedMethods(List.of(
                 "GET",

--- a/frontend/src/plugins/axios.js
+++ b/frontend/src/plugins/axios.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const api = axios.create({
-  baseURL: 'http://localhost:8080',
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080',
 })
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- Replace hardcoded `localhost:8080` in axios with `VITE_API_BASE_URL` env variable for production builds
- Update CORS policy to read allowed origins from `cors.allowed-origins` property (defaults to Vite dev ports locally, set via Azure App Service config in prod)
- Add multi-stage `Dockerfile` for the Spring Boot backend (Maven build → JRE runtime)
- Add GitHub Actions `deploy.yml` workflow that deploys the JAR to Azure App Service and the frontend dist to Azure Static Web Apps on push to `main`

## Azure Resources Provisioned
| Resource | Name |
|---|---|
| App Service | `project-pulse-api-km` |
| MySQL Flexible Server | `project-pulse-db-km` (West US 2, Burstable B1ms) |
| Database | `project_pulse` |
| Static Web App | `project-pulse-ui` (East US 2) |

## Required GitHub Secrets / Variables
Before merging, confirm these are set under Settings → Secrets and variables → Actions:
- **Secret** `AZURE_WEBAPP_PUBLISH_PROFILE`
- **Secret** `AZURE_STATIC_WEB_APPS_API_TOKEN`
- **Variable** `AZURE_WEBAPP_NAME` = `project-pulse-api-km`
- **Variable** `VITE_API_BASE_URL` = `https://project-pulse-api-km.azurewebsites.net`

## Test Plan
- [x] Confirm all 4 GitHub secrets/variables are set
- [x] Merge to `main` and verify both deploy jobs pass in Actions
- [x] Visit `https://project-pulse-api-km.azurewebsites.net/actuator/health` (or any public endpoint) to confirm backend is up
- [x] Visit `https://orange-pebble-06afc810f.7.azurestaticapps.net` to confirm frontend loads
- [x] Log in and verify API calls succeed end-to-end